### PR TITLE
chore: add npmrc security hardening for supply-chain protection

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,13 @@
+# Security hardening: disable lifecycle scripts (including postinstall) to reduce npm supply-chain risk.
+# npm docs: https://docs.npmjs.com/cli/v10/using-npm/config#ignore-scripts
+# See also https://snyk.io/articles/npm-security-best-practices-shai-hulud-attack/
+ignore-scripts=true
+
+# Security hardening: reject git-based dependencies (git+ssh://, github: URLs, etc.).
+allow-git=none
+
+# Security hardening: skip package versions published less than 7 days ago (based on CISA's guidance).
+min-release-age=7
+
+# Fail on peer dependency conflicts so dependabot PRs with broken peer deps are rejected.
+strict-peer-deps=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,7 @@
 # Security hardening: disable lifecycle scripts (including postinstall) to reduce npm supply-chain risk.
 # npm docs: https://docs.npmjs.com/cli/v10/using-npm/config#ignore-scripts
 # See also https://snyk.io/articles/npm-security-best-practices-shai-hulud-attack/
+# Note: this also prevents automatic execution of this repo's `prepare` script (husky). To enable git hooks locally, run `npm run prepare` after install.
 ignore-scripts=true
 
 # Security hardening: reject git-based dependencies (git+ssh://, github: URLs, etc.).


### PR DESCRIPTION
## Summary

- Add a root `.npmrc` with npm security hardening settings for this package
- Disable lifecycle scripts (`ignore-scripts=true`) to reduce supply-chain risk from postinstall hooks
- Reject git-based dependencies (`allow-git=none`)
- Skip package versions published less than 7 days ago (`min-release-age=7`)
- Fail on peer dependency conflicts (`strict-peer-deps=true`) so broken Dependabot PRs are rejected early

## Test plan

- [ ] Verify CI passes with the new `.npmrc` in place
- [ ] Confirm `npm install` still works for this repo's dependencies
- [ ] Confirm Dependabot PRs with peer dependency conflicts fail as expected