### PR TITLE
fix(release): correct verify-publishable bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "./typescript/js-lib": "./dist/typescript/js-lib.json"
   },
   "bin": {
-    "verify-publishable": "./dist/semantic-release/verify-publishable.js"
+    "verify-publishable": "dist/semantic-release/verify-publishable.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- Remove the leading `./` from the `verify-publishable` npm bin path in `package.json`
- Aligns the bin entry with npm conventions for published package executables

## Test plan
- [ ] `npm run build`
- [ ] `npx verify-publishable` resolves and runs after install/pack