### PR TITLE
fix(typescript): set rootDir for TS 6.0 build partials

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": ["./typescript/base.json", "./typescript/js-lib.json"],
   "compilerOptions": {
+    "rootDir": ".",
     "skipLibCheck": true,
     "types": ["node"]
   },

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -64,7 +64,7 @@ In case you're developing a library with a dedicated build process, we recommend
 
 The lib partials set `rootDir` to `./src` so build output lands in `dist/` without an extra `src/` segment (required since TypeScript 6.0). Override `rootDir` in your build config if your sources live elsewhere.
 
-with the following `package.json` `scripts`:
+With the following `package.json` `scripts`:
 
 ```json
 {

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -62,6 +62,8 @@ In case you're developing a library with a dedicated build process, we recommend
 }
 ```
 
+The lib partials set `rootDir` to `./src` so build output lands in `dist/` without an extra `src/` segment (required since TypeScript 6.0). Override `rootDir` in your build config if your sources live elsewhere.
+
 with the following `package.json` `scripts`:
 
 ```json

--- a/typescript/js-lib.json
+++ b/typescript/js-lib.json
@@ -4,7 +4,8 @@
     "lib": ["es2022"],
     "declaration": true,
     "noEmit": false,
-    "outDir": "${configDir}/dist"
+    "outDir": "${configDir}/dist",
+    "rootDir": "${configDir}/src"
   },
   "$schema": "https://json.schemastore.org/tsconfig"
 }

--- a/typescript/lib.json
+++ b/typescript/lib.json
@@ -6,6 +6,7 @@
     "declarationMap": true,
     "noEmit": false,
     "outDir": "${configDir}/dist",
+    "rootDir": "${configDir}/src",
     "sourceMap": true,
     // Use inlineSources: true because often we only publish the dist folder on npm
     "inlineSources": true


### PR DESCRIPTION
## Summary
- Set `rootDir` to `${configDir}/src` in `typescript/lib` and `typescript/js-lib` build partials so emit output stays flat in `dist/` under TypeScript 6.0
- Override `rootDir` to `.` in this repo's root `tsconfig.json` for its flat source layout
- Document the default and override guidance in `typescript/README.md`

## Test plan
- [x] `tsc --noEmit` passes locally
- [x] `tsc` build emits declarations to `dist/` only (no source-tree `.d.ts` pollution)
- [ ] CI passes on PR