### PR TITLE
feat(eslint): add config snapshots and tighten string coercion rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ Run targeted checks for touched scope first, then broader checks before finishin
   - `npm run test:styles:prefer-interface`
   - `npm run test:styles:jsx-no-literals`
   - `npm run test:rules:vitest`
+  - `npm run test:snapshot` — if this fails, follow [`eslint/review-config-snapshot.prompt.md`](./eslint/review-config-snapshot.prompt.md)
 
 If your change affects publishing behavior, also verify:
 
@@ -88,6 +89,7 @@ If your change affects publishing behavior, also verify:
 - Ensure fixture tests in matching `*.test` folders demonstrate intended pass/fail cases.
 - For style rules (`eslint/styles/*`), document trade-offs in comments/docs when behavior is opinionated.
 - Preserve test relaxations where intended; strictness is context-dependent (app code vs tests).
+- When [`config-snapshot.test.js`](./eslint/config-snapshot.test.js) fails (often after a dependency upgrade), follow [`eslint/review-config-snapshot.prompt.md`](./eslint/review-config-snapshot.prompt.md): update snapshots, review the diff, adjust rule sources if needed, and ask the user for final judgement before committing.
 
 ### Prettier changes (`prettier/`)
 

--- a/eslint/__snapshots__/javascript-browser.json
+++ b/eslint/__snapshots__/javascript-browser.json
@@ -1,0 +1,2391 @@
+{
+  "main.js": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      1,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      1,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [2],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      1,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "declaration",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      2,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [1, 5],
+    "max-len": [0],
+    "max-nested-callbacks": [1, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [1],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [1],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [2],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [2],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      2,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [2],
+    "no-dupe-class-members": [2],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [2],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [2],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [1],
+    "no-import-assign": [2],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [1],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [2],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [2],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      2,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [2],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [2],
+    "no-throw-literal": [1],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      2,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [2],
+    "no-unreachable-loop": [
+      1,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      2,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      1,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [1],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [1],
+    "no-whitespace-before-property": [0],
+    "no-with": [2],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      1,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-const": [
+      1,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      1,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [1],
+    "prefer-spread": [1],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-yield": [2],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [2],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  },
+  "main.test.js": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      1,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [2],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      1,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "declaration",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      2,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [0, 5],
+    "max-len": [0],
+    "max-nested-callbacks": [0, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [1],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [0],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [2],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [2],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      0,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [2],
+    "no-dupe-class-members": [2],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [2],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [2],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [1],
+    "no-import-assign": [2],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [0],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [2],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [2],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-only-tests/no-only-tests": [2],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      2,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [2],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [2],
+    "no-throw-literal": [1],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      2,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [2],
+    "no-unreachable-loop": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      2,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [1],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [1],
+    "no-whitespace-before-property": [0],
+    "no-with": [2],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      0,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-const": [
+      1,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      1,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [1],
+    "prefer-spread": [1],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-yield": [0],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [0],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  }
+}

--- a/eslint/__snapshots__/javascript-node.json
+++ b/eslint/__snapshots__/javascript-node.json
@@ -1,0 +1,2391 @@
+{
+  "main.js": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      1,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      1,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [2],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      1,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "declaration",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      2,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [1, 5],
+    "max-len": [0],
+    "max-nested-callbacks": [1, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [1],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [1],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [2],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [2],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      2,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [2],
+    "no-dupe-class-members": [2],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [2],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [2],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [1],
+    "no-import-assign": [2],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [1],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [2],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [2],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      2,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [2],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [2],
+    "no-throw-literal": [1],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      2,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [2],
+    "no-unreachable-loop": [
+      1,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      2,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      1,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [1],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [1],
+    "no-whitespace-before-property": [0],
+    "no-with": [2],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      1,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-const": [
+      1,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      1,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [1],
+    "prefer-spread": [1],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-yield": [2],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [2],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  },
+  "main.test.js": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      1,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [2],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      1,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "declaration",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      2,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [0, 5],
+    "max-len": [0],
+    "max-nested-callbacks": [0, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [1],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [0],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [2],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [2],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      0,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [2],
+    "no-dupe-class-members": [2],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [2],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [2],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [1],
+    "no-import-assign": [2],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [0],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [2],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [2],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-only-tests/no-only-tests": [2],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      2,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [2],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [2],
+    "no-throw-literal": [1],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      2,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [2],
+    "no-unreachable-loop": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      2,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [1],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [1],
+    "no-whitespace-before-property": [0],
+    "no-with": [2],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      0,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-const": [
+      1,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      1,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [1],
+    "prefer-spread": [1],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-yield": [0],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [0],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  }
+}

--- a/eslint/__snapshots__/javascript.json
+++ b/eslint/__snapshots__/javascript.json
@@ -1,0 +1,2391 @@
+{
+  "main.js": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      1,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      1,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [2],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      1,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "declaration",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      2,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [1, 5],
+    "max-len": [0],
+    "max-nested-callbacks": [1, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [1],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [1],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [2],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [2],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      2,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [2],
+    "no-dupe-class-members": [2],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [2],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [2],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [1],
+    "no-import-assign": [2],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [1],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [2],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [2],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      2,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [2],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [2],
+    "no-throw-literal": [1],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      2,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [2],
+    "no-unreachable-loop": [
+      1,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      2,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      1,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [1],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [1],
+    "no-whitespace-before-property": [0],
+    "no-with": [2],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      1,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-const": [
+      1,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      1,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [1],
+    "prefer-spread": [1],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-yield": [2],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [2],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  },
+  "main.test.js": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      1,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [2],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      1,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "declaration",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      2,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [0, 5],
+    "max-len": [0],
+    "max-nested-callbacks": [0, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [1],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [0],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [2],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [2],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      0,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [2],
+    "no-dupe-class-members": [2],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [2],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [2],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [1],
+    "no-import-assign": [2],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [0],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [2],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [2],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-only-tests/no-only-tests": [2],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      2,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [2],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [2],
+    "no-throw-literal": [1],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      2,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [2],
+    "no-unreachable-loop": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      2,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [1],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [1],
+    "no-whitespace-before-property": [0],
+    "no-with": [2],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      0,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-const": [
+      1,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      1,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [1],
+    "prefer-spread": [1],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-yield": [0],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [0],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  }
+}

--- a/eslint/__snapshots__/typescript-node.json
+++ b/eslint/__snapshots__/typescript-node.json
@@ -1,0 +1,4739 @@
+{
+  "main.ts": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/adjacent-overload-signatures": [2],
+    "@typescript-eslint/array-type": [
+      1,
+      {
+        "default": "generic"
+      }
+    ],
+    "@typescript-eslint/await-thenable": [2],
+    "@typescript-eslint/ban-ts-comment": [
+      1,
+      {
+        "ts-expect-error": "allow-with-description"
+      }
+    ],
+    "@typescript-eslint/ban-tslint-comment": [2],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/class-literal-property-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/consistent-generic-constructors": [2],
+    "@typescript-eslint/consistent-indexed-object-style": [2],
+    "@typescript-eslint/consistent-type-assertions": [2],
+    "@typescript-eslint/consistent-type-definitions": [1, "type"],
+    "@typescript-eslint/dot-notation": [
+      2,
+      {
+        "allowIndexSignaturePropertyAccess": false,
+        "allowKeywords": true,
+        "allowPattern": "",
+        "allowPrivateClassPropertyAccess": false,
+        "allowProtectedClassPropertyAccess": false
+      }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      1,
+      {
+        "accessibility": "no-public",
+        "overrides": {
+          "parameterProperties": "explicit"
+        }
+      }
+    ],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/method-signature-style": [1, "property"],
+    "@typescript-eslint/naming-convention": [
+      1,
+      {
+        "selector": "default",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "parameter",
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "method",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "variable",
+        "modifiers": ["destructured"],
+        "format": null
+      },
+      {
+        "selector": [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember"
+        ],
+        "modifiers": ["requiresQuotes"],
+        "format": null
+      },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "variable"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "function"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameter"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "property"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameterProperty"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "method"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "accessor"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enumMember"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "class"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "interface"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeAlias"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enum"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeParameter"
+      }
+    ],
+    "@typescript-eslint/no-array-constructor": [2],
+    "@typescript-eslint/no-array-delete": [2],
+    "@typescript-eslint/no-base-to-string": [2],
+    "@typescript-eslint/no-confusing-non-null-assertion": [2],
+    "@typescript-eslint/no-confusing-void-expression": [
+      0,
+      {
+        "ignoreArrowShorthand": true,
+        "ignoreVoidOperator": true
+      }
+    ],
+    "@typescript-eslint/no-deprecated": [2],
+    "@typescript-eslint/no-duplicate-enum-values": [2],
+    "@typescript-eslint/no-duplicate-type-constituents": [2],
+    "@typescript-eslint/no-dynamic-delete": [2],
+    "@typescript-eslint/no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "@typescript-eslint/no-empty-interface": [0],
+    "@typescript-eslint/no-empty-object-type": [2],
+    "@typescript-eslint/no-explicit-any": [
+      0,
+      {
+        "fixToUnknown": false,
+        "ignoreRestArgs": true
+      }
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [2],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/no-extraneous-class": [2],
+    "@typescript-eslint/no-floating-promises": [2],
+    "@typescript-eslint/no-for-in-array": [2],
+    "@typescript-eslint/no-implied-eval": [2],
+    "@typescript-eslint/no-inferrable-types": [2],
+    "@typescript-eslint/no-invalid-void-type": [2],
+    "@typescript-eslint/no-meaningless-void-operator": [2],
+    "@typescript-eslint/no-misused-new": [2],
+    "@typescript-eslint/no-misused-promises": [2],
+    "@typescript-eslint/no-misused-spread": [2],
+    "@typescript-eslint/no-mixed-enums": [2],
+    "@typescript-eslint/no-namespace": [2],
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [2],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [2],
+    "@typescript-eslint/no-non-null-assertion": [0],
+    "@typescript-eslint/no-redundant-type-constituents": [2],
+    "@typescript-eslint/no-require-imports": [2],
+    "@typescript-eslint/no-this-alias": [2],
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": [0],
+    "@typescript-eslint/no-unnecessary-condition": [
+      1,
+      {
+        "allowConstantLoopConditions": true
+      }
+    ],
+    "@typescript-eslint/no-unnecessary-qualifier": [1],
+    "@typescript-eslint/no-unnecessary-template-expression": [2],
+    "@typescript-eslint/no-unnecessary-type-arguments": [2],
+    "@typescript-eslint/no-unnecessary-type-assertion": [2],
+    "@typescript-eslint/no-unnecessary-type-constraint": [2],
+    "@typescript-eslint/no-unnecessary-type-conversion": [2],
+    "@typescript-eslint/no-unnecessary-type-parameters": [2],
+    "@typescript-eslint/no-unsafe-argument": [0],
+    "@typescript-eslint/no-unsafe-assignment": [0],
+    "@typescript-eslint/no-unsafe-call": [0],
+    "@typescript-eslint/no-unsafe-declaration-merging": [2],
+    "@typescript-eslint/no-unsafe-enum-comparison": [2],
+    "@typescript-eslint/no-unsafe-function-type": [2],
+    "@typescript-eslint/no-unsafe-member-access": [0],
+    "@typescript-eslint/no-unsafe-return": [2],
+    "@typescript-eslint/no-unsafe-unary-minus": [2],
+    "@typescript-eslint/no-unused-expressions": [
+      1,
+      {
+        "allowShortCircuit": true,
+        "allowTaggedTemplates": false,
+        "allowTernary": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "@typescript-eslint/no-useless-constructor": [2],
+    "@typescript-eslint/no-useless-default-assignment": [2],
+    "@typescript-eslint/no-wrapper-object-types": [2],
+    "@typescript-eslint/non-nullable-type-assertion-style": [2],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/only-throw-error": [2],
+    "@typescript-eslint/prefer-as-const": [2],
+    "@typescript-eslint/prefer-find": [2],
+    "@typescript-eslint/prefer-for-of": [2],
+    "@typescript-eslint/prefer-function-type": [2],
+    "@typescript-eslint/prefer-includes": [2],
+    "@typescript-eslint/prefer-literal-enum-member": [2],
+    "@typescript-eslint/prefer-namespace-keyword": [2],
+    "@typescript-eslint/prefer-nullish-coalescing": [2],
+    "@typescript-eslint/prefer-optional-chain": [2],
+    "@typescript-eslint/prefer-promise-reject-errors": [2],
+    "@typescript-eslint/prefer-reduce-type-parameter": [2],
+    "@typescript-eslint/prefer-regexp-exec": [2],
+    "@typescript-eslint/prefer-return-this-type": [2],
+    "@typescript-eslint/prefer-string-starts-ends-with": [2],
+    "@typescript-eslint/promise-function-async": [
+      1,
+      {
+        "allowAny": true,
+        "allowedPromiseNames": [],
+        "checkArrowFunctions": true,
+        "checkFunctionDeclarations": true,
+        "checkFunctionExpressions": true,
+        "checkMethodDeclarations": true
+      }
+    ],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/related-getter-setter-pairs": [2],
+    "@typescript-eslint/require-await": [0],
+    "@typescript-eslint/restrict-plus-operands": [
+      2,
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": true,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      0,
+      {
+        "allowBoolean": false,
+        "allowNullable": false,
+        "allowNumber": true
+      }
+    ],
+    "@typescript-eslint/return-await": [1, "in-try-catch"],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/switch-exhaustiveness-check": [
+      1,
+      {
+        "considerDefaultExhaustiveForUnions": true
+      }
+    ],
+    "@typescript-eslint/triple-slash-reference": [2],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "@typescript-eslint/unbound-method": [2],
+    "@typescript-eslint/unified-signatures": [2],
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      0,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [0],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      0,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "expression",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      0,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [1, 5],
+    "max-len": [0],
+    "max-lines": [
+      1,
+      {
+        "max": 1400,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-nested-callbacks": [1, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [0],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [1],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [0],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [0],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      2,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [0],
+    "no-dupe-class-members": [0],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [0],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [0],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [0],
+    "no-import-assign": [0],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [1],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [0],
+    "no-new-symbol": [0],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [0],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      0,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-return-await": [0],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [0],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [0],
+    "no-throw-literal": [0],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      0,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [0],
+    "no-unreachable-loop": [
+      1,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      0,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [0],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [2],
+    "no-whitespace-before-property": [0],
+    "no-with": [0],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      1,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-arrow/prefer-arrow-functions": [
+      1,
+      {
+        "disallowPrototype": false,
+        "singleReturnOnly": false,
+        "classPropertiesAllowed": false
+      }
+    ],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      0,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [2],
+    "prefer-spread": [2],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-await": [0],
+    "require-yield": [2],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [2],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  },
+  "main.d.ts": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/adjacent-overload-signatures": [2],
+    "@typescript-eslint/array-type": [
+      1,
+      {
+        "default": "generic"
+      }
+    ],
+    "@typescript-eslint/await-thenable": [2],
+    "@typescript-eslint/ban-ts-comment": [
+      1,
+      {
+        "ts-expect-error": "allow-with-description"
+      }
+    ],
+    "@typescript-eslint/ban-tslint-comment": [2],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/class-literal-property-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/consistent-generic-constructors": [2],
+    "@typescript-eslint/consistent-indexed-object-style": [2],
+    "@typescript-eslint/consistent-type-assertions": [2],
+    "@typescript-eslint/consistent-type-definitions": [0, "type"],
+    "@typescript-eslint/dot-notation": [
+      2,
+      {
+        "allowIndexSignaturePropertyAccess": false,
+        "allowKeywords": true,
+        "allowPattern": "",
+        "allowPrivateClassPropertyAccess": false,
+        "allowProtectedClassPropertyAccess": false
+      }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      1,
+      {
+        "accessibility": "no-public",
+        "overrides": {
+          "parameterProperties": "explicit"
+        }
+      }
+    ],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/method-signature-style": [0, "property"],
+    "@typescript-eslint/naming-convention": [
+      0,
+      {
+        "selector": "default",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "parameter",
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "method",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "variable",
+        "modifiers": ["destructured"],
+        "format": null
+      },
+      {
+        "selector": [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember"
+        ],
+        "modifiers": ["requiresQuotes"],
+        "format": null
+      },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "variable"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "function"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameter"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "property"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameterProperty"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "method"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "accessor"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enumMember"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "class"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "interface"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeAlias"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enum"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeParameter"
+      }
+    ],
+    "@typescript-eslint/no-array-constructor": [2],
+    "@typescript-eslint/no-array-delete": [2],
+    "@typescript-eslint/no-base-to-string": [2],
+    "@typescript-eslint/no-confusing-non-null-assertion": [2],
+    "@typescript-eslint/no-confusing-void-expression": [
+      0,
+      {
+        "ignoreArrowShorthand": true,
+        "ignoreVoidOperator": true
+      }
+    ],
+    "@typescript-eslint/no-deprecated": [2],
+    "@typescript-eslint/no-duplicate-enum-values": [2],
+    "@typescript-eslint/no-duplicate-type-constituents": [2],
+    "@typescript-eslint/no-dynamic-delete": [2],
+    "@typescript-eslint/no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "@typescript-eslint/no-empty-interface": [0],
+    "@typescript-eslint/no-empty-object-type": [2],
+    "@typescript-eslint/no-explicit-any": [
+      0,
+      {
+        "fixToUnknown": false,
+        "ignoreRestArgs": true
+      }
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [2],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/no-extraneous-class": [2],
+    "@typescript-eslint/no-floating-promises": [2],
+    "@typescript-eslint/no-for-in-array": [2],
+    "@typescript-eslint/no-implied-eval": [2],
+    "@typescript-eslint/no-inferrable-types": [2],
+    "@typescript-eslint/no-invalid-void-type": [2],
+    "@typescript-eslint/no-meaningless-void-operator": [2],
+    "@typescript-eslint/no-misused-new": [2],
+    "@typescript-eslint/no-misused-promises": [2],
+    "@typescript-eslint/no-misused-spread": [2],
+    "@typescript-eslint/no-mixed-enums": [2],
+    "@typescript-eslint/no-namespace": [2],
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [2],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [2],
+    "@typescript-eslint/no-non-null-assertion": [0],
+    "@typescript-eslint/no-redundant-type-constituents": [2],
+    "@typescript-eslint/no-require-imports": [2],
+    "@typescript-eslint/no-this-alias": [2],
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": [0],
+    "@typescript-eslint/no-unnecessary-condition": [
+      1,
+      {
+        "allowConstantLoopConditions": true
+      }
+    ],
+    "@typescript-eslint/no-unnecessary-qualifier": [1],
+    "@typescript-eslint/no-unnecessary-template-expression": [2],
+    "@typescript-eslint/no-unnecessary-type-arguments": [2],
+    "@typescript-eslint/no-unnecessary-type-assertion": [2],
+    "@typescript-eslint/no-unnecessary-type-constraint": [2],
+    "@typescript-eslint/no-unnecessary-type-conversion": [2],
+    "@typescript-eslint/no-unnecessary-type-parameters": [2],
+    "@typescript-eslint/no-unsafe-argument": [0],
+    "@typescript-eslint/no-unsafe-assignment": [0],
+    "@typescript-eslint/no-unsafe-call": [0],
+    "@typescript-eslint/no-unsafe-declaration-merging": [2],
+    "@typescript-eslint/no-unsafe-enum-comparison": [2],
+    "@typescript-eslint/no-unsafe-function-type": [2],
+    "@typescript-eslint/no-unsafe-member-access": [0],
+    "@typescript-eslint/no-unsafe-return": [2],
+    "@typescript-eslint/no-unsafe-unary-minus": [2],
+    "@typescript-eslint/no-unused-expressions": [
+      1,
+      {
+        "allowShortCircuit": true,
+        "allowTaggedTemplates": false,
+        "allowTernary": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "@typescript-eslint/no-useless-constructor": [2],
+    "@typescript-eslint/no-useless-default-assignment": [2],
+    "@typescript-eslint/no-wrapper-object-types": [2],
+    "@typescript-eslint/non-nullable-type-assertion-style": [2],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/only-throw-error": [2],
+    "@typescript-eslint/prefer-as-const": [2],
+    "@typescript-eslint/prefer-find": [2],
+    "@typescript-eslint/prefer-for-of": [2],
+    "@typescript-eslint/prefer-function-type": [2],
+    "@typescript-eslint/prefer-includes": [2],
+    "@typescript-eslint/prefer-literal-enum-member": [2],
+    "@typescript-eslint/prefer-namespace-keyword": [2],
+    "@typescript-eslint/prefer-nullish-coalescing": [2],
+    "@typescript-eslint/prefer-optional-chain": [2],
+    "@typescript-eslint/prefer-promise-reject-errors": [2],
+    "@typescript-eslint/prefer-reduce-type-parameter": [2],
+    "@typescript-eslint/prefer-regexp-exec": [2],
+    "@typescript-eslint/prefer-return-this-type": [2],
+    "@typescript-eslint/prefer-string-starts-ends-with": [2],
+    "@typescript-eslint/promise-function-async": [
+      1,
+      {
+        "allowAny": true,
+        "allowedPromiseNames": [],
+        "checkArrowFunctions": true,
+        "checkFunctionDeclarations": true,
+        "checkFunctionExpressions": true,
+        "checkMethodDeclarations": true
+      }
+    ],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/related-getter-setter-pairs": [2],
+    "@typescript-eslint/require-await": [0],
+    "@typescript-eslint/restrict-plus-operands": [
+      2,
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": true,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      0,
+      {
+        "allowBoolean": false,
+        "allowNullable": false,
+        "allowNumber": true
+      }
+    ],
+    "@typescript-eslint/return-await": [1, "in-try-catch"],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/switch-exhaustiveness-check": [
+      1,
+      {
+        "considerDefaultExhaustiveForUnions": true
+      }
+    ],
+    "@typescript-eslint/triple-slash-reference": [2],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "@typescript-eslint/unbound-method": [2],
+    "@typescript-eslint/unified-signatures": [2],
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      0,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [0],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      0,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "expression",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      0,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "import/no-default-export": [0],
+    "import/no-unassigned-import": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [1, 5],
+    "max-len": [0],
+    "max-lines": [
+      1,
+      {
+        "max": 1400,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-nested-callbacks": [1, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [0],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [1],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [0],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [0],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      2,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [0],
+    "no-dupe-class-members": [0],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [0],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [0],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [0],
+    "no-import-assign": [0],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [1],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [0],
+    "no-new-symbol": [0],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [0],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      0,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-return-await": [0],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [0],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [0],
+    "no-throw-literal": [0],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      0,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [0],
+    "no-unreachable-loop": [
+      1,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      0,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [0],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [2],
+    "no-whitespace-before-property": [0],
+    "no-with": [0],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      1,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-arrow/prefer-arrow-functions": [
+      1,
+      {
+        "disallowPrototype": false,
+        "singleReturnOnly": false,
+        "classPropertiesAllowed": false
+      }
+    ],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      0,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [2],
+    "prefer-spread": [2],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-await": [0],
+    "require-yield": [2],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [2],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  },
+  "main.test.ts": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/adjacent-overload-signatures": [2],
+    "@typescript-eslint/array-type": [
+      1,
+      {
+        "default": "generic"
+      }
+    ],
+    "@typescript-eslint/await-thenable": [2],
+    "@typescript-eslint/ban-ts-comment": [
+      1,
+      {
+        "ts-expect-error": "allow-with-description"
+      }
+    ],
+    "@typescript-eslint/ban-tslint-comment": [2],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/class-literal-property-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/consistent-generic-constructors": [2],
+    "@typescript-eslint/consistent-indexed-object-style": [2],
+    "@typescript-eslint/consistent-type-assertions": [0],
+    "@typescript-eslint/consistent-type-definitions": [1, "type"],
+    "@typescript-eslint/dot-notation": [
+      2,
+      {
+        "allowIndexSignaturePropertyAccess": false,
+        "allowKeywords": true,
+        "allowPattern": "",
+        "allowPrivateClassPropertyAccess": false,
+        "allowProtectedClassPropertyAccess": false
+      }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      1,
+      {
+        "accessibility": "no-public",
+        "overrides": {
+          "parameterProperties": "explicit"
+        }
+      }
+    ],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/method-signature-style": [1, "property"],
+    "@typescript-eslint/naming-convention": [
+      0,
+      {
+        "selector": "default",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "parameter",
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "method",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "variable",
+        "modifiers": ["destructured"],
+        "format": null
+      },
+      {
+        "selector": [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember"
+        ],
+        "modifiers": ["requiresQuotes"],
+        "format": null
+      },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "variable"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "function"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameter"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "property"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameterProperty"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "method"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "accessor"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enumMember"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "class"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "interface"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeAlias"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enum"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeParameter"
+      }
+    ],
+    "@typescript-eslint/no-array-constructor": [2],
+    "@typescript-eslint/no-array-delete": [2],
+    "@typescript-eslint/no-base-to-string": [2],
+    "@typescript-eslint/no-confusing-non-null-assertion": [2],
+    "@typescript-eslint/no-confusing-void-expression": [
+      0,
+      {
+        "ignoreArrowShorthand": true,
+        "ignoreVoidOperator": true
+      }
+    ],
+    "@typescript-eslint/no-deprecated": [2],
+    "@typescript-eslint/no-duplicate-enum-values": [2],
+    "@typescript-eslint/no-duplicate-type-constituents": [2],
+    "@typescript-eslint/no-dynamic-delete": [2],
+    "@typescript-eslint/no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "@typescript-eslint/no-empty-interface": [0],
+    "@typescript-eslint/no-empty-object-type": [2],
+    "@typescript-eslint/no-explicit-any": [
+      0,
+      {
+        "fixToUnknown": false,
+        "ignoreRestArgs": true
+      }
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [2],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/no-extraneous-class": [2],
+    "@typescript-eslint/no-floating-promises": [2],
+    "@typescript-eslint/no-for-in-array": [2],
+    "@typescript-eslint/no-implied-eval": [2],
+    "@typescript-eslint/no-inferrable-types": [2],
+    "@typescript-eslint/no-invalid-void-type": [2],
+    "@typescript-eslint/no-meaningless-void-operator": [2],
+    "@typescript-eslint/no-misused-new": [2],
+    "@typescript-eslint/no-misused-promises": [2],
+    "@typescript-eslint/no-misused-spread": [2],
+    "@typescript-eslint/no-mixed-enums": [2],
+    "@typescript-eslint/no-namespace": [2],
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [2],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [2],
+    "@typescript-eslint/no-non-null-assertion": [0],
+    "@typescript-eslint/no-redundant-type-constituents": [2],
+    "@typescript-eslint/no-require-imports": [2],
+    "@typescript-eslint/no-this-alias": [2],
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": [0],
+    "@typescript-eslint/no-unnecessary-condition": [
+      0,
+      {
+        "allowConstantLoopConditions": true
+      }
+    ],
+    "@typescript-eslint/no-unnecessary-qualifier": [1],
+    "@typescript-eslint/no-unnecessary-template-expression": [2],
+    "@typescript-eslint/no-unnecessary-type-arguments": [2],
+    "@typescript-eslint/no-unnecessary-type-assertion": [2],
+    "@typescript-eslint/no-unnecessary-type-constraint": [2],
+    "@typescript-eslint/no-unnecessary-type-conversion": [2],
+    "@typescript-eslint/no-unnecessary-type-parameters": [2],
+    "@typescript-eslint/no-unsafe-argument": [0],
+    "@typescript-eslint/no-unsafe-assignment": [0],
+    "@typescript-eslint/no-unsafe-call": [0],
+    "@typescript-eslint/no-unsafe-declaration-merging": [2],
+    "@typescript-eslint/no-unsafe-enum-comparison": [2],
+    "@typescript-eslint/no-unsafe-function-type": [2],
+    "@typescript-eslint/no-unsafe-member-access": [0],
+    "@typescript-eslint/no-unsafe-return": [0],
+    "@typescript-eslint/no-unsafe-unary-minus": [2],
+    "@typescript-eslint/no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTaggedTemplates": false,
+        "allowTernary": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "@typescript-eslint/no-useless-constructor": [2],
+    "@typescript-eslint/no-useless-default-assignment": [2],
+    "@typescript-eslint/no-wrapper-object-types": [2],
+    "@typescript-eslint/non-nullable-type-assertion-style": [2],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/only-throw-error": [2],
+    "@typescript-eslint/prefer-as-const": [2],
+    "@typescript-eslint/prefer-find": [2],
+    "@typescript-eslint/prefer-for-of": [2],
+    "@typescript-eslint/prefer-function-type": [2],
+    "@typescript-eslint/prefer-includes": [2],
+    "@typescript-eslint/prefer-literal-enum-member": [2],
+    "@typescript-eslint/prefer-namespace-keyword": [2],
+    "@typescript-eslint/prefer-nullish-coalescing": [2],
+    "@typescript-eslint/prefer-optional-chain": [2],
+    "@typescript-eslint/prefer-promise-reject-errors": [2],
+    "@typescript-eslint/prefer-reduce-type-parameter": [2],
+    "@typescript-eslint/prefer-regexp-exec": [2],
+    "@typescript-eslint/prefer-return-this-type": [2],
+    "@typescript-eslint/prefer-string-starts-ends-with": [2],
+    "@typescript-eslint/promise-function-async": [
+      0,
+      {
+        "allowAny": true,
+        "allowedPromiseNames": [],
+        "checkArrowFunctions": true,
+        "checkFunctionDeclarations": true,
+        "checkFunctionExpressions": true,
+        "checkMethodDeclarations": true
+      }
+    ],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/related-getter-setter-pairs": [2],
+    "@typescript-eslint/require-await": [0],
+    "@typescript-eslint/restrict-plus-operands": [
+      2,
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": true,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      0,
+      {
+        "allowBoolean": false,
+        "allowNullable": false,
+        "allowNumber": true
+      }
+    ],
+    "@typescript-eslint/return-await": [1, "in-try-catch"],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/switch-exhaustiveness-check": [
+      1,
+      {
+        "considerDefaultExhaustiveForUnions": true
+      }
+    ],
+    "@typescript-eslint/triple-slash-reference": [2],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "@typescript-eslint/unbound-method": [0],
+    "@typescript-eslint/unified-signatures": [2],
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      0,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [0],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      0,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "expression",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      0,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [0, 5],
+    "max-len": [0],
+    "max-lines": [
+      1,
+      {
+        "max": 1400,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-nested-callbacks": [0, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [0],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [0],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [0],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [0],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      0,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [0],
+    "no-dupe-class-members": [0],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [0],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [0],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [0],
+    "no-import-assign": [0],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [0],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [0],
+    "no-new-symbol": [0],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [0],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-only-tests/no-only-tests": [2],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      0,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-return-await": [0],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [0],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [0],
+    "no-throw-literal": [0],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      0,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [0],
+    "no-unreachable-loop": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      0,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [0],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [2],
+    "no-whitespace-before-property": [0],
+    "no-with": [0],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      0,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-arrow/prefer-arrow-functions": [
+      1,
+      {
+        "disallowPrototype": false,
+        "singleReturnOnly": false,
+        "classPropertiesAllowed": false
+      }
+    ],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      0,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [2],
+    "prefer-spread": [2],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-await": [0],
+    "require-yield": [0],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [0],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  }
+}

--- a/eslint/__snapshots__/typescript-react.json
+++ b/eslint/__snapshots__/typescript-react.json
@@ -1,0 +1,5419 @@
+{
+  "main.tsx": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@eslint-react/dom-no-dangerously-set-innerhtml": [1],
+    "@eslint-react/dom-no-dangerously-set-innerhtml-with-children": [2],
+    "@eslint-react/dom-no-find-dom-node": [2],
+    "@eslint-react/dom-no-flush-sync": [2],
+    "@eslint-react/dom-no-hydrate": [2],
+    "@eslint-react/dom-no-missing-button-type": [1],
+    "@eslint-react/dom-no-missing-iframe-sandbox": [1],
+    "@eslint-react/dom-no-render": [2],
+    "@eslint-react/dom-no-render-return-value": [2],
+    "@eslint-react/dom-no-script-url": [1],
+    "@eslint-react/dom-no-unknown-property": [1],
+    "@eslint-react/dom-no-unsafe-iframe-sandbox": [1],
+    "@eslint-react/dom-no-use-form-state": [2],
+    "@eslint-react/dom-no-void-elements-with-children": [2],
+    "@eslint-react/error-boundaries": [2],
+    "@eslint-react/exhaustive-deps": [1],
+    "@eslint-react/globals": [1],
+    "@eslint-react/immutability": [1],
+    "@eslint-react/jsx-no-children-prop": [1],
+    "@eslint-react/jsx-no-children-prop-with-children": [2],
+    "@eslint-react/jsx-no-comment-textnodes": [1],
+    "@eslint-react/jsx-no-key-after-spread": [2],
+    "@eslint-react/jsx-no-leaked-dollar": [1],
+    "@eslint-react/jsx-no-leaked-semicolon": [1],
+    "@eslint-react/jsx-no-namespace": [2],
+    "@eslint-react/naming-convention-context-name": [1],
+    "@eslint-react/naming-convention-id-name": [1],
+    "@eslint-react/naming-convention-ref-name": [1],
+    "@eslint-react/no-access-state-in-setstate": [2],
+    "@eslint-react/no-array-index-key": [1],
+    "@eslint-react/no-children-count": [1],
+    "@eslint-react/no-children-for-each": [1],
+    "@eslint-react/no-children-map": [1],
+    "@eslint-react/no-children-only": [1],
+    "@eslint-react/no-children-to-array": [1],
+    "@eslint-react/no-clone-element": [1],
+    "@eslint-react/no-component-will-mount": [2],
+    "@eslint-react/no-component-will-receive-props": [2],
+    "@eslint-react/no-component-will-update": [2],
+    "@eslint-react/no-context-provider": [1],
+    "@eslint-react/no-create-ref": [2],
+    "@eslint-react/no-direct-mutation-state": [2],
+    "@eslint-react/no-forward-ref": [1],
+    "@eslint-react/no-leaked-conditional-rendering": [2],
+    "@eslint-react/no-missing-component-display-name": [1],
+    "@eslint-react/no-missing-context-display-name": [1],
+    "@eslint-react/no-missing-key": [2],
+    "@eslint-react/no-nested-component-definitions": [2],
+    "@eslint-react/no-nested-lazy-component-declarations": [2],
+    "@eslint-react/no-set-state-in-component-did-mount": [1],
+    "@eslint-react/no-set-state-in-component-did-update": [1],
+    "@eslint-react/no-set-state-in-component-will-update": [1],
+    "@eslint-react/no-unnecessary-use-prefix": [1],
+    "@eslint-react/no-unsafe-component-will-mount": [1],
+    "@eslint-react/no-unsafe-component-will-receive-props": [1],
+    "@eslint-react/no-unsafe-component-will-update": [1],
+    "@eslint-react/no-unstable-context-value": [1],
+    "@eslint-react/no-unused-class-component-members": [1],
+    "@eslint-react/no-unused-state": [1],
+    "@eslint-react/no-use-context": [1],
+    "@eslint-react/purity": [1],
+    "@eslint-react/refs": [1],
+    "@eslint-react/rsc-function-definition": [2],
+    "@eslint-react/rules-of-hooks": [2],
+    "@eslint-react/set-state-in-effect": [1],
+    "@eslint-react/set-state-in-render": [2],
+    "@eslint-react/static-components": [2],
+    "@eslint-react/unsupported-syntax": [2],
+    "@eslint-react/use-memo": [2],
+    "@eslint-react/use-state": [1],
+    "@eslint-react/web-api-no-leaked-event-listener": [1],
+    "@eslint-react/web-api-no-leaked-fetch": [1],
+    "@eslint-react/web-api-no-leaked-intersection-observer": [1],
+    "@eslint-react/web-api-no-leaked-interval": [1],
+    "@eslint-react/web-api-no-leaked-resize-observer": [1],
+    "@eslint-react/web-api-no-leaked-timeout": [1],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/adjacent-overload-signatures": [2],
+    "@typescript-eslint/array-type": [
+      1,
+      {
+        "default": "generic"
+      }
+    ],
+    "@typescript-eslint/await-thenable": [2],
+    "@typescript-eslint/ban-ts-comment": [
+      1,
+      {
+        "ts-expect-error": "allow-with-description"
+      }
+    ],
+    "@typescript-eslint/ban-tslint-comment": [2],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/class-literal-property-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/consistent-generic-constructors": [2],
+    "@typescript-eslint/consistent-indexed-object-style": [2],
+    "@typescript-eslint/consistent-type-assertions": [2],
+    "@typescript-eslint/consistent-type-definitions": [1, "type"],
+    "@typescript-eslint/dot-notation": [
+      2,
+      {
+        "allowIndexSignaturePropertyAccess": false,
+        "allowKeywords": true,
+        "allowPattern": "",
+        "allowPrivateClassPropertyAccess": false,
+        "allowProtectedClassPropertyAccess": false
+      }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      1,
+      {
+        "accessibility": "no-public",
+        "overrides": {
+          "parameterProperties": "explicit"
+        }
+      }
+    ],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/method-signature-style": [1, "property"],
+    "@typescript-eslint/naming-convention": [
+      1,
+      {
+        "selector": "default",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "parameter",
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "method",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "variable",
+        "modifiers": ["destructured"],
+        "format": null
+      },
+      {
+        "selector": [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember"
+        ],
+        "modifiers": ["requiresQuotes"],
+        "format": null
+      },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "variable"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "function"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameter"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "property"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameterProperty"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "method"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "accessor"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enumMember"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "class"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "interface"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeAlias"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enum"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeParameter"
+      }
+    ],
+    "@typescript-eslint/no-array-constructor": [2],
+    "@typescript-eslint/no-array-delete": [2],
+    "@typescript-eslint/no-base-to-string": [2],
+    "@typescript-eslint/no-confusing-non-null-assertion": [2],
+    "@typescript-eslint/no-confusing-void-expression": [
+      0,
+      {
+        "ignoreArrowShorthand": true,
+        "ignoreVoidOperator": true
+      }
+    ],
+    "@typescript-eslint/no-deprecated": [2],
+    "@typescript-eslint/no-duplicate-enum-values": [2],
+    "@typescript-eslint/no-duplicate-type-constituents": [2],
+    "@typescript-eslint/no-dynamic-delete": [2],
+    "@typescript-eslint/no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "@typescript-eslint/no-empty-interface": [0],
+    "@typescript-eslint/no-empty-object-type": [2],
+    "@typescript-eslint/no-explicit-any": [
+      0,
+      {
+        "fixToUnknown": false,
+        "ignoreRestArgs": true
+      }
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [2],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/no-extraneous-class": [2],
+    "@typescript-eslint/no-floating-promises": [2],
+    "@typescript-eslint/no-for-in-array": [2],
+    "@typescript-eslint/no-implied-eval": [2],
+    "@typescript-eslint/no-inferrable-types": [2],
+    "@typescript-eslint/no-invalid-void-type": [2],
+    "@typescript-eslint/no-meaningless-void-operator": [2],
+    "@typescript-eslint/no-misused-new": [2],
+    "@typescript-eslint/no-misused-promises": [2],
+    "@typescript-eslint/no-misused-spread": [2],
+    "@typescript-eslint/no-mixed-enums": [2],
+    "@typescript-eslint/no-namespace": [2],
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [2],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [2],
+    "@typescript-eslint/no-non-null-assertion": [0],
+    "@typescript-eslint/no-redundant-type-constituents": [2],
+    "@typescript-eslint/no-require-imports": [2],
+    "@typescript-eslint/no-this-alias": [2],
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": [0],
+    "@typescript-eslint/no-unnecessary-condition": [
+      1,
+      {
+        "allowConstantLoopConditions": true
+      }
+    ],
+    "@typescript-eslint/no-unnecessary-qualifier": [1],
+    "@typescript-eslint/no-unnecessary-template-expression": [2],
+    "@typescript-eslint/no-unnecessary-type-arguments": [2],
+    "@typescript-eslint/no-unnecessary-type-assertion": [2],
+    "@typescript-eslint/no-unnecessary-type-constraint": [2],
+    "@typescript-eslint/no-unnecessary-type-conversion": [2],
+    "@typescript-eslint/no-unnecessary-type-parameters": [2],
+    "@typescript-eslint/no-unsafe-argument": [0],
+    "@typescript-eslint/no-unsafe-assignment": [0],
+    "@typescript-eslint/no-unsafe-call": [0],
+    "@typescript-eslint/no-unsafe-declaration-merging": [2],
+    "@typescript-eslint/no-unsafe-enum-comparison": [2],
+    "@typescript-eslint/no-unsafe-function-type": [2],
+    "@typescript-eslint/no-unsafe-member-access": [0],
+    "@typescript-eslint/no-unsafe-return": [2],
+    "@typescript-eslint/no-unsafe-unary-minus": [2],
+    "@typescript-eslint/no-unused-expressions": [
+      1,
+      {
+        "allowShortCircuit": true,
+        "allowTaggedTemplates": false,
+        "allowTernary": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "@typescript-eslint/no-useless-constructor": [2],
+    "@typescript-eslint/no-useless-default-assignment": [2],
+    "@typescript-eslint/no-wrapper-object-types": [2],
+    "@typescript-eslint/non-nullable-type-assertion-style": [2],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/only-throw-error": [2],
+    "@typescript-eslint/prefer-as-const": [2],
+    "@typescript-eslint/prefer-find": [2],
+    "@typescript-eslint/prefer-for-of": [2],
+    "@typescript-eslint/prefer-function-type": [2],
+    "@typescript-eslint/prefer-includes": [2],
+    "@typescript-eslint/prefer-literal-enum-member": [2],
+    "@typescript-eslint/prefer-namespace-keyword": [2],
+    "@typescript-eslint/prefer-nullish-coalescing": [2],
+    "@typescript-eslint/prefer-optional-chain": [2],
+    "@typescript-eslint/prefer-promise-reject-errors": [2],
+    "@typescript-eslint/prefer-reduce-type-parameter": [2],
+    "@typescript-eslint/prefer-regexp-exec": [2],
+    "@typescript-eslint/prefer-return-this-type": [2],
+    "@typescript-eslint/prefer-string-starts-ends-with": [2],
+    "@typescript-eslint/promise-function-async": [
+      1,
+      {
+        "allowAny": true,
+        "allowedPromiseNames": [],
+        "checkArrowFunctions": true,
+        "checkFunctionDeclarations": true,
+        "checkFunctionExpressions": true,
+        "checkMethodDeclarations": true
+      }
+    ],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/related-getter-setter-pairs": [2],
+    "@typescript-eslint/require-await": [0],
+    "@typescript-eslint/restrict-plus-operands": [
+      2,
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": true,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      0,
+      {
+        "allowBoolean": false,
+        "allowNullable": false,
+        "allowNumber": true
+      }
+    ],
+    "@typescript-eslint/return-await": [1, "in-try-catch"],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/switch-exhaustiveness-check": [
+      1,
+      {
+        "considerDefaultExhaustiveForUnions": true
+      }
+    ],
+    "@typescript-eslint/triple-slash-reference": [2],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "@typescript-eslint/unbound-method": [2],
+    "@typescript-eslint/unified-signatures": [2],
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      0,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [0],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      0,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "expression",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      0,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-a11y/alt-text": [2],
+    "jsx-a11y/anchor-ambiguous-text": [0],
+    "jsx-a11y/anchor-has-content": [2],
+    "jsx-a11y/anchor-is-valid": [2],
+    "jsx-a11y/aria-activedescendant-has-tabindex": [2],
+    "jsx-a11y/aria-props": [2],
+    "jsx-a11y/aria-proptypes": [2],
+    "jsx-a11y/aria-role": [2],
+    "jsx-a11y/aria-unsupported-elements": [2],
+    "jsx-a11y/autocomplete-valid": [2],
+    "jsx-a11y/click-events-have-key-events": [2],
+    "jsx-a11y/control-has-associated-label": [
+      0,
+      {
+        "ignoreElements": [
+          "audio",
+          "canvas",
+          "embed",
+          "input",
+          "textarea",
+          "tr",
+          "video"
+        ],
+        "ignoreRoles": [
+          "grid",
+          "listbox",
+          "menu",
+          "menubar",
+          "radiogroup",
+          "row",
+          "tablist",
+          "toolbar",
+          "tree",
+          "treegrid"
+        ],
+        "includeRoles": ["alert", "dialog"]
+      }
+    ],
+    "jsx-a11y/heading-has-content": [2],
+    "jsx-a11y/html-has-lang": [2],
+    "jsx-a11y/iframe-has-title": [2],
+    "jsx-a11y/img-redundant-alt": [2],
+    "jsx-a11y/interactive-supports-focus": [
+      2,
+      {
+        "tabbable": [
+          "button",
+          "checkbox",
+          "link",
+          "progressbar",
+          "searchbox",
+          "slider",
+          "spinbutton",
+          "switch",
+          "textbox"
+        ]
+      }
+    ],
+    "jsx-a11y/label-has-associated-control": [2],
+    "jsx-a11y/label-has-for": [0],
+    "jsx-a11y/media-has-caption": [2],
+    "jsx-a11y/mouse-events-have-key-events": [2],
+    "jsx-a11y/no-access-key": [2],
+    "jsx-a11y/no-autofocus": [2],
+    "jsx-a11y/no-distracting-elements": [2],
+    "jsx-a11y/no-interactive-element-to-noninteractive-role": [
+      2,
+      {
+        "tr": ["none", "presentation"],
+        "canvas": ["img"]
+      }
+    ],
+    "jsx-a11y/no-noninteractive-element-interactions": [
+      2,
+      {
+        "body": ["onError", "onLoad"],
+        "iframe": ["onError", "onLoad"],
+        "img": ["onError", "onLoad"]
+      }
+    ],
+    "jsx-a11y/no-noninteractive-element-to-interactive-role": [
+      2,
+      {
+        "ul": [
+          "listbox",
+          "menu",
+          "menubar",
+          "radiogroup",
+          "tablist",
+          "tree",
+          "treegrid"
+        ],
+        "ol": [
+          "listbox",
+          "menu",
+          "menubar",
+          "radiogroup",
+          "tablist",
+          "tree",
+          "treegrid"
+        ],
+        "li": [
+          "menuitem",
+          "menuitemradio",
+          "menuitemcheckbox",
+          "option",
+          "row",
+          "tab",
+          "treeitem"
+        ],
+        "table": ["grid"],
+        "td": ["gridcell"],
+        "fieldset": ["radiogroup", "presentation"]
+      }
+    ],
+    "jsx-a11y/no-noninteractive-tabindex": [
+      2,
+      {
+        "tags": [],
+        "roles": ["tabpanel"],
+        "allowExpressionValues": true
+      }
+    ],
+    "jsx-a11y/no-redundant-roles": [2],
+    "jsx-a11y/no-static-element-interactions": [
+      2,
+      {
+        "allowExpressionValues": true,
+        "handlers": [
+          "onClick",
+          "onMouseDown",
+          "onMouseUp",
+          "onKeyPress",
+          "onKeyDown",
+          "onKeyUp"
+        ]
+      }
+    ],
+    "jsx-a11y/role-has-required-aria-props": [2],
+    "jsx-a11y/role-supports-aria-props": [2],
+    "jsx-a11y/scope": [2],
+    "jsx-a11y/tabindex-no-positive": [2],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [1, 5],
+    "max-len": [0],
+    "max-lines": [
+      1,
+      {
+        "max": 1400,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-nested-callbacks": [1, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [0],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [1],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [0],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [0],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      2,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [0],
+    "no-dupe-class-members": [0],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [0],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [0],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [0],
+    "no-import-assign": [0],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [1],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [0],
+    "no-new-symbol": [0],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [0],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      0,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-return-await": [0],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [0],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [0],
+    "no-throw-literal": [0],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      0,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [0],
+    "no-unreachable-loop": [
+      1,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      0,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [0],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [2],
+    "no-whitespace-before-property": [0],
+    "no-with": [0],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      1,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-arrow/prefer-arrow-functions": [
+      1,
+      {
+        "disallowPrototype": false,
+        "singleReturnOnly": false,
+        "classPropertiesAllowed": false
+      }
+    ],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      0,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [2],
+    "prefer-spread": [2],
+    "quote-props": [0],
+    "quotes": [0],
+    "react-hooks/config": [2],
+    "react-hooks/error-boundaries": [0],
+    "react-hooks/exhaustive-deps": [0],
+    "react-hooks/gating": [2],
+    "react-hooks/globals": [0],
+    "react-hooks/immutability": [0],
+    "react-hooks/incompatible-library": [1],
+    "react-hooks/preserve-manual-memoization": [2],
+    "react-hooks/purity": [0],
+    "react-hooks/refs": [0],
+    "react-hooks/rules-of-hooks": [0],
+    "react-hooks/set-state-in-effect": [0],
+    "react-hooks/set-state-in-render": [0],
+    "react-hooks/static-components": [0],
+    "react-hooks/unsupported-syntax": [0],
+    "react-hooks/use-memo": [0],
+    "react-refresh/only-export-components": [
+      1,
+      {
+        "allowConstantExport": true,
+        "allowExportNames": [
+          "getServerSideProps",
+          "meta",
+          "links",
+          "headers",
+          "loader",
+          "action"
+        ]
+      }
+    ],
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": [1],
+    "react-you-might-not-need-an-effect/no-chain-state-updates": [1],
+    "react-you-might-not-need-an-effect/no-derived-state": [1],
+    "react-you-might-not-need-an-effect/no-event-handler": [1],
+    "react-you-might-not-need-an-effect/no-external-store-subscription": [1],
+    "react-you-might-not-need-an-effect/no-initialize-state": [1],
+    "react-you-might-not-need-an-effect/no-pass-data-to-parent": [1],
+    "react-you-might-not-need-an-effect/no-pass-live-state-to-parent": [1],
+    "react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change": [1],
+    "react/button-has-type": [0],
+    "react/default-props-match-prop-types": [1],
+    "react/destructuring-assignment": [0],
+    "react/display-name": [0],
+    "react/forbid-foreign-prop-types": [1],
+    "react/forbid-prop-types": [
+      1,
+      {
+        "checkChildContextTypes": true,
+        "checkContextTypes": true
+      }
+    ],
+    "react/forward-ref-uses-ref": [0],
+    "react/hook-use-state": [0],
+    "react/iframe-missing-sandbox": [0],
+    "react/jsx-boolean-value": [1, "never"],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-brace-presence": [1, "never"],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-filename-extension": [
+      1,
+      {
+        "extensions": [".jsx", ".tsx"]
+      }
+    ],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-fragments": [0],
+    "react/jsx-handler-names": [
+      1,
+      {
+        "eventHandlerPrefix": "handle",
+        "eventHandlerPropPrefix": "on"
+      }
+    ],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-key": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-no-comment-textnodes": [0],
+    "react/jsx-no-constructed-context-values": [0],
+    "react/jsx-no-duplicate-props": [2],
+    "react/jsx-no-leaked-render": [0],
+    "react/jsx-no-script-url": [0],
+    "react/jsx-no-target-blank": [0],
+    "react/jsx-no-undef": [1],
+    "react/jsx-no-useless-fragment": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-pascal-case": [1],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-props-no-spread-multi": [1],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-uses-react": [0],
+    "react/jsx-uses-vars": [2],
+    "react/jsx-wrap-multilines": [0],
+    "react/no-access-state-in-setstate": [0],
+    "react/no-array-index-key": [0],
+    "react/no-children-prop": [0],
+    "react/no-danger": [0],
+    "react/no-danger-with-children": [0],
+    "react/no-deprecated": [0],
+    "react/no-did-mount-set-state": [0],
+    "react/no-did-update-set-state": [0],
+    "react/no-direct-mutation-state": [0],
+    "react/no-find-dom-node": [0],
+    "react/no-invalid-html-attribute": [1],
+    "react/no-is-mounted": [2],
+    "react/no-namespace": [0],
+    "react/no-object-type-as-default-prop": [0],
+    "react/no-redundant-should-component-update": [1],
+    "react/no-render-return-value": [0],
+    "react/no-string-refs": [0],
+    "react/no-this-in-sfc": [1],
+    "react/no-typos": [1],
+    "react/no-unescaped-entities": [2],
+    "react/no-unknown-property": [0],
+    "react/no-unsafe": [0],
+    "react/no-unstable-nested-components": [0],
+    "react/no-unused-class-component-members": [0],
+    "react/no-unused-prop-types": [1],
+    "react/no-unused-state": [0],
+    "react/no-will-update-set-state": [0],
+    "react/prefer-es6-class": [1],
+    "react/prefer-stateless-function": [
+      1,
+      {
+        "ignorePureComponents": true
+      }
+    ],
+    "react/prop-types": [0],
+    "react/react-in-jsx-scope": [0],
+    "react/require-render-return": [2],
+    "react/self-closing-comp": [1],
+    "react/style-prop-object": [1],
+    "react/void-dom-elements-no-children": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-await": [0],
+    "require-yield": [2],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [2],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  },
+  "main.ts": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/adjacent-overload-signatures": [2],
+    "@typescript-eslint/array-type": [
+      1,
+      {
+        "default": "generic"
+      }
+    ],
+    "@typescript-eslint/await-thenable": [2],
+    "@typescript-eslint/ban-ts-comment": [
+      1,
+      {
+        "ts-expect-error": "allow-with-description"
+      }
+    ],
+    "@typescript-eslint/ban-tslint-comment": [2],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/class-literal-property-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/consistent-generic-constructors": [2],
+    "@typescript-eslint/consistent-indexed-object-style": [2],
+    "@typescript-eslint/consistent-type-assertions": [2],
+    "@typescript-eslint/consistent-type-definitions": [1, "type"],
+    "@typescript-eslint/dot-notation": [
+      2,
+      {
+        "allowIndexSignaturePropertyAccess": false,
+        "allowKeywords": true,
+        "allowPattern": "",
+        "allowPrivateClassPropertyAccess": false,
+        "allowProtectedClassPropertyAccess": false
+      }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      1,
+      {
+        "accessibility": "no-public",
+        "overrides": {
+          "parameterProperties": "explicit"
+        }
+      }
+    ],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/method-signature-style": [1, "property"],
+    "@typescript-eslint/naming-convention": [
+      1,
+      {
+        "selector": "default",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "parameter",
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "method",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "variable",
+        "modifiers": ["destructured"],
+        "format": null
+      },
+      {
+        "selector": [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember"
+        ],
+        "modifiers": ["requiresQuotes"],
+        "format": null
+      },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "variable"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "function"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameter"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "property"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameterProperty"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "method"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "accessor"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enumMember"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "class"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "interface"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeAlias"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enum"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeParameter"
+      }
+    ],
+    "@typescript-eslint/no-array-constructor": [2],
+    "@typescript-eslint/no-array-delete": [2],
+    "@typescript-eslint/no-base-to-string": [2],
+    "@typescript-eslint/no-confusing-non-null-assertion": [2],
+    "@typescript-eslint/no-confusing-void-expression": [
+      0,
+      {
+        "ignoreArrowShorthand": true,
+        "ignoreVoidOperator": true
+      }
+    ],
+    "@typescript-eslint/no-deprecated": [2],
+    "@typescript-eslint/no-duplicate-enum-values": [2],
+    "@typescript-eslint/no-duplicate-type-constituents": [2],
+    "@typescript-eslint/no-dynamic-delete": [2],
+    "@typescript-eslint/no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "@typescript-eslint/no-empty-interface": [0],
+    "@typescript-eslint/no-empty-object-type": [2],
+    "@typescript-eslint/no-explicit-any": [
+      0,
+      {
+        "fixToUnknown": false,
+        "ignoreRestArgs": true
+      }
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [2],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/no-extraneous-class": [2],
+    "@typescript-eslint/no-floating-promises": [2],
+    "@typescript-eslint/no-for-in-array": [2],
+    "@typescript-eslint/no-implied-eval": [2],
+    "@typescript-eslint/no-inferrable-types": [2],
+    "@typescript-eslint/no-invalid-void-type": [2],
+    "@typescript-eslint/no-meaningless-void-operator": [2],
+    "@typescript-eslint/no-misused-new": [2],
+    "@typescript-eslint/no-misused-promises": [2],
+    "@typescript-eslint/no-misused-spread": [2],
+    "@typescript-eslint/no-mixed-enums": [2],
+    "@typescript-eslint/no-namespace": [2],
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [2],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [2],
+    "@typescript-eslint/no-non-null-assertion": [0],
+    "@typescript-eslint/no-redundant-type-constituents": [2],
+    "@typescript-eslint/no-require-imports": [2],
+    "@typescript-eslint/no-this-alias": [2],
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": [0],
+    "@typescript-eslint/no-unnecessary-condition": [
+      1,
+      {
+        "allowConstantLoopConditions": true
+      }
+    ],
+    "@typescript-eslint/no-unnecessary-qualifier": [1],
+    "@typescript-eslint/no-unnecessary-template-expression": [2],
+    "@typescript-eslint/no-unnecessary-type-arguments": [2],
+    "@typescript-eslint/no-unnecessary-type-assertion": [2],
+    "@typescript-eslint/no-unnecessary-type-constraint": [2],
+    "@typescript-eslint/no-unnecessary-type-conversion": [2],
+    "@typescript-eslint/no-unnecessary-type-parameters": [2],
+    "@typescript-eslint/no-unsafe-argument": [0],
+    "@typescript-eslint/no-unsafe-assignment": [0],
+    "@typescript-eslint/no-unsafe-call": [0],
+    "@typescript-eslint/no-unsafe-declaration-merging": [2],
+    "@typescript-eslint/no-unsafe-enum-comparison": [2],
+    "@typescript-eslint/no-unsafe-function-type": [2],
+    "@typescript-eslint/no-unsafe-member-access": [0],
+    "@typescript-eslint/no-unsafe-return": [2],
+    "@typescript-eslint/no-unsafe-unary-minus": [2],
+    "@typescript-eslint/no-unused-expressions": [
+      1,
+      {
+        "allowShortCircuit": true,
+        "allowTaggedTemplates": false,
+        "allowTernary": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "@typescript-eslint/no-useless-constructor": [2],
+    "@typescript-eslint/no-useless-default-assignment": [2],
+    "@typescript-eslint/no-wrapper-object-types": [2],
+    "@typescript-eslint/non-nullable-type-assertion-style": [2],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/only-throw-error": [2],
+    "@typescript-eslint/prefer-as-const": [2],
+    "@typescript-eslint/prefer-find": [2],
+    "@typescript-eslint/prefer-for-of": [2],
+    "@typescript-eslint/prefer-function-type": [2],
+    "@typescript-eslint/prefer-includes": [2],
+    "@typescript-eslint/prefer-literal-enum-member": [2],
+    "@typescript-eslint/prefer-namespace-keyword": [2],
+    "@typescript-eslint/prefer-nullish-coalescing": [2],
+    "@typescript-eslint/prefer-optional-chain": [2],
+    "@typescript-eslint/prefer-promise-reject-errors": [2],
+    "@typescript-eslint/prefer-reduce-type-parameter": [2],
+    "@typescript-eslint/prefer-regexp-exec": [2],
+    "@typescript-eslint/prefer-return-this-type": [2],
+    "@typescript-eslint/prefer-string-starts-ends-with": [2],
+    "@typescript-eslint/promise-function-async": [
+      1,
+      {
+        "allowAny": true,
+        "allowedPromiseNames": [],
+        "checkArrowFunctions": true,
+        "checkFunctionDeclarations": true,
+        "checkFunctionExpressions": true,
+        "checkMethodDeclarations": true
+      }
+    ],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/related-getter-setter-pairs": [2],
+    "@typescript-eslint/require-await": [0],
+    "@typescript-eslint/restrict-plus-operands": [
+      2,
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": true,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      0,
+      {
+        "allowBoolean": false,
+        "allowNullable": false,
+        "allowNumber": true
+      }
+    ],
+    "@typescript-eslint/return-await": [1, "in-try-catch"],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/switch-exhaustiveness-check": [
+      1,
+      {
+        "considerDefaultExhaustiveForUnions": true
+      }
+    ],
+    "@typescript-eslint/triple-slash-reference": [2],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "@typescript-eslint/unbound-method": [2],
+    "@typescript-eslint/unified-signatures": [2],
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      0,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [0],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      0,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "expression",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      0,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [1, 5],
+    "max-len": [0],
+    "max-lines": [
+      1,
+      {
+        "max": 1400,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-nested-callbacks": [1, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [0],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [1],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [0],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [0],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      2,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [0],
+    "no-dupe-class-members": [0],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [0],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [0],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [0],
+    "no-import-assign": [0],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [1],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [0],
+    "no-new-symbol": [0],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [0],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      0,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-return-await": [0],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [0],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [0],
+    "no-throw-literal": [0],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      0,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [0],
+    "no-unreachable-loop": [
+      1,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      0,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [0],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [2],
+    "no-whitespace-before-property": [0],
+    "no-with": [0],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      1,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-arrow/prefer-arrow-functions": [
+      1,
+      {
+        "disallowPrototype": false,
+        "singleReturnOnly": false,
+        "classPropertiesAllowed": false
+      }
+    ],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      0,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [2],
+    "prefer-spread": [2],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-await": [0],
+    "require-yield": [2],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [2],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  },
+  "main.test.tsx": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@eslint-react/dom-no-dangerously-set-innerhtml": [1],
+    "@eslint-react/dom-no-dangerously-set-innerhtml-with-children": [2],
+    "@eslint-react/dom-no-find-dom-node": [2],
+    "@eslint-react/dom-no-flush-sync": [2],
+    "@eslint-react/dom-no-hydrate": [2],
+    "@eslint-react/dom-no-missing-button-type": [1],
+    "@eslint-react/dom-no-missing-iframe-sandbox": [1],
+    "@eslint-react/dom-no-render": [2],
+    "@eslint-react/dom-no-render-return-value": [2],
+    "@eslint-react/dom-no-script-url": [1],
+    "@eslint-react/dom-no-unknown-property": [1],
+    "@eslint-react/dom-no-unsafe-iframe-sandbox": [1],
+    "@eslint-react/dom-no-use-form-state": [2],
+    "@eslint-react/dom-no-void-elements-with-children": [2],
+    "@eslint-react/error-boundaries": [2],
+    "@eslint-react/exhaustive-deps": [0],
+    "@eslint-react/globals": [1],
+    "@eslint-react/immutability": [1],
+    "@eslint-react/jsx-no-children-prop": [1],
+    "@eslint-react/jsx-no-children-prop-with-children": [2],
+    "@eslint-react/jsx-no-comment-textnodes": [1],
+    "@eslint-react/jsx-no-key-after-spread": [2],
+    "@eslint-react/jsx-no-leaked-dollar": [1],
+    "@eslint-react/jsx-no-leaked-semicolon": [1],
+    "@eslint-react/jsx-no-namespace": [2],
+    "@eslint-react/naming-convention-context-name": [1],
+    "@eslint-react/naming-convention-id-name": [1],
+    "@eslint-react/naming-convention-ref-name": [1],
+    "@eslint-react/no-access-state-in-setstate": [2],
+    "@eslint-react/no-array-index-key": [1],
+    "@eslint-react/no-children-count": [1],
+    "@eslint-react/no-children-for-each": [1],
+    "@eslint-react/no-children-map": [1],
+    "@eslint-react/no-children-only": [1],
+    "@eslint-react/no-children-to-array": [1],
+    "@eslint-react/no-clone-element": [1],
+    "@eslint-react/no-component-will-mount": [2],
+    "@eslint-react/no-component-will-receive-props": [2],
+    "@eslint-react/no-component-will-update": [2],
+    "@eslint-react/no-context-provider": [1],
+    "@eslint-react/no-create-ref": [2],
+    "@eslint-react/no-direct-mutation-state": [2],
+    "@eslint-react/no-forward-ref": [1],
+    "@eslint-react/no-leaked-conditional-rendering": [2],
+    "@eslint-react/no-missing-component-display-name": [0],
+    "@eslint-react/no-missing-context-display-name": [1],
+    "@eslint-react/no-missing-key": [2],
+    "@eslint-react/no-nested-component-definitions": [2],
+    "@eslint-react/no-nested-lazy-component-declarations": [2],
+    "@eslint-react/no-set-state-in-component-did-mount": [1],
+    "@eslint-react/no-set-state-in-component-did-update": [1],
+    "@eslint-react/no-set-state-in-component-will-update": [1],
+    "@eslint-react/no-unnecessary-use-prefix": [1],
+    "@eslint-react/no-unsafe-component-will-mount": [1],
+    "@eslint-react/no-unsafe-component-will-receive-props": [1],
+    "@eslint-react/no-unsafe-component-will-update": [1],
+    "@eslint-react/no-unstable-context-value": [1],
+    "@eslint-react/no-unused-class-component-members": [1],
+    "@eslint-react/no-unused-state": [1],
+    "@eslint-react/no-use-context": [1],
+    "@eslint-react/purity": [1],
+    "@eslint-react/refs": [1],
+    "@eslint-react/rsc-function-definition": [2],
+    "@eslint-react/rules-of-hooks": [2],
+    "@eslint-react/set-state-in-effect": [1],
+    "@eslint-react/set-state-in-render": [2],
+    "@eslint-react/static-components": [2],
+    "@eslint-react/unsupported-syntax": [2],
+    "@eslint-react/use-memo": [2],
+    "@eslint-react/use-state": [1],
+    "@eslint-react/web-api-no-leaked-event-listener": [1],
+    "@eslint-react/web-api-no-leaked-fetch": [1],
+    "@eslint-react/web-api-no-leaked-intersection-observer": [1],
+    "@eslint-react/web-api-no-leaked-interval": [1],
+    "@eslint-react/web-api-no-leaked-resize-observer": [1],
+    "@eslint-react/web-api-no-leaked-timeout": [1],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/adjacent-overload-signatures": [2],
+    "@typescript-eslint/array-type": [
+      1,
+      {
+        "default": "generic"
+      }
+    ],
+    "@typescript-eslint/await-thenable": [2],
+    "@typescript-eslint/ban-ts-comment": [
+      1,
+      {
+        "ts-expect-error": "allow-with-description"
+      }
+    ],
+    "@typescript-eslint/ban-tslint-comment": [2],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/class-literal-property-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/consistent-generic-constructors": [2],
+    "@typescript-eslint/consistent-indexed-object-style": [2],
+    "@typescript-eslint/consistent-type-assertions": [0],
+    "@typescript-eslint/consistent-type-definitions": [1, "type"],
+    "@typescript-eslint/dot-notation": [
+      2,
+      {
+        "allowIndexSignaturePropertyAccess": false,
+        "allowKeywords": true,
+        "allowPattern": "",
+        "allowPrivateClassPropertyAccess": false,
+        "allowProtectedClassPropertyAccess": false
+      }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      1,
+      {
+        "accessibility": "no-public",
+        "overrides": {
+          "parameterProperties": "explicit"
+        }
+      }
+    ],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/method-signature-style": [1, "property"],
+    "@typescript-eslint/naming-convention": [
+      0,
+      {
+        "selector": "default",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "parameter",
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "method",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "variable",
+        "modifiers": ["destructured"],
+        "format": null
+      },
+      {
+        "selector": [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember"
+        ],
+        "modifiers": ["requiresQuotes"],
+        "format": null
+      },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "variable"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "function"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameter"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "property"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameterProperty"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "method"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "accessor"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enumMember"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "class"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "interface"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeAlias"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enum"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeParameter"
+      }
+    ],
+    "@typescript-eslint/no-array-constructor": [2],
+    "@typescript-eslint/no-array-delete": [2],
+    "@typescript-eslint/no-base-to-string": [2],
+    "@typescript-eslint/no-confusing-non-null-assertion": [2],
+    "@typescript-eslint/no-confusing-void-expression": [
+      0,
+      {
+        "ignoreArrowShorthand": true,
+        "ignoreVoidOperator": true
+      }
+    ],
+    "@typescript-eslint/no-deprecated": [2],
+    "@typescript-eslint/no-duplicate-enum-values": [2],
+    "@typescript-eslint/no-duplicate-type-constituents": [2],
+    "@typescript-eslint/no-dynamic-delete": [2],
+    "@typescript-eslint/no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "@typescript-eslint/no-empty-interface": [0],
+    "@typescript-eslint/no-empty-object-type": [2],
+    "@typescript-eslint/no-explicit-any": [
+      0,
+      {
+        "fixToUnknown": false,
+        "ignoreRestArgs": true
+      }
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [2],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/no-extraneous-class": [2],
+    "@typescript-eslint/no-floating-promises": [2],
+    "@typescript-eslint/no-for-in-array": [2],
+    "@typescript-eslint/no-implied-eval": [2],
+    "@typescript-eslint/no-inferrable-types": [2],
+    "@typescript-eslint/no-invalid-void-type": [2],
+    "@typescript-eslint/no-meaningless-void-operator": [2],
+    "@typescript-eslint/no-misused-new": [2],
+    "@typescript-eslint/no-misused-promises": [2],
+    "@typescript-eslint/no-misused-spread": [2],
+    "@typescript-eslint/no-mixed-enums": [2],
+    "@typescript-eslint/no-namespace": [2],
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [2],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [2],
+    "@typescript-eslint/no-non-null-assertion": [0],
+    "@typescript-eslint/no-redundant-type-constituents": [2],
+    "@typescript-eslint/no-require-imports": [2],
+    "@typescript-eslint/no-this-alias": [2],
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": [0],
+    "@typescript-eslint/no-unnecessary-condition": [
+      0,
+      {
+        "allowConstantLoopConditions": true
+      }
+    ],
+    "@typescript-eslint/no-unnecessary-qualifier": [1],
+    "@typescript-eslint/no-unnecessary-template-expression": [2],
+    "@typescript-eslint/no-unnecessary-type-arguments": [2],
+    "@typescript-eslint/no-unnecessary-type-assertion": [2],
+    "@typescript-eslint/no-unnecessary-type-constraint": [2],
+    "@typescript-eslint/no-unnecessary-type-conversion": [2],
+    "@typescript-eslint/no-unnecessary-type-parameters": [2],
+    "@typescript-eslint/no-unsafe-argument": [0],
+    "@typescript-eslint/no-unsafe-assignment": [0],
+    "@typescript-eslint/no-unsafe-call": [0],
+    "@typescript-eslint/no-unsafe-declaration-merging": [2],
+    "@typescript-eslint/no-unsafe-enum-comparison": [2],
+    "@typescript-eslint/no-unsafe-function-type": [2],
+    "@typescript-eslint/no-unsafe-member-access": [0],
+    "@typescript-eslint/no-unsafe-return": [0],
+    "@typescript-eslint/no-unsafe-unary-minus": [2],
+    "@typescript-eslint/no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTaggedTemplates": false,
+        "allowTernary": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "@typescript-eslint/no-useless-constructor": [2],
+    "@typescript-eslint/no-useless-default-assignment": [2],
+    "@typescript-eslint/no-wrapper-object-types": [2],
+    "@typescript-eslint/non-nullable-type-assertion-style": [2],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/only-throw-error": [2],
+    "@typescript-eslint/prefer-as-const": [2],
+    "@typescript-eslint/prefer-find": [2],
+    "@typescript-eslint/prefer-for-of": [2],
+    "@typescript-eslint/prefer-function-type": [2],
+    "@typescript-eslint/prefer-includes": [2],
+    "@typescript-eslint/prefer-literal-enum-member": [2],
+    "@typescript-eslint/prefer-namespace-keyword": [2],
+    "@typescript-eslint/prefer-nullish-coalescing": [2],
+    "@typescript-eslint/prefer-optional-chain": [2],
+    "@typescript-eslint/prefer-promise-reject-errors": [2],
+    "@typescript-eslint/prefer-reduce-type-parameter": [2],
+    "@typescript-eslint/prefer-regexp-exec": [2],
+    "@typescript-eslint/prefer-return-this-type": [2],
+    "@typescript-eslint/prefer-string-starts-ends-with": [2],
+    "@typescript-eslint/promise-function-async": [
+      0,
+      {
+        "allowAny": true,
+        "allowedPromiseNames": [],
+        "checkArrowFunctions": true,
+        "checkFunctionDeclarations": true,
+        "checkFunctionExpressions": true,
+        "checkMethodDeclarations": true
+      }
+    ],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/related-getter-setter-pairs": [2],
+    "@typescript-eslint/require-await": [0],
+    "@typescript-eslint/restrict-plus-operands": [
+      2,
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": true,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      0,
+      {
+        "allowBoolean": false,
+        "allowNullable": false,
+        "allowNumber": true
+      }
+    ],
+    "@typescript-eslint/return-await": [1, "in-try-catch"],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/switch-exhaustiveness-check": [
+      1,
+      {
+        "considerDefaultExhaustiveForUnions": true
+      }
+    ],
+    "@typescript-eslint/triple-slash-reference": [2],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "@typescript-eslint/unbound-method": [0],
+    "@typescript-eslint/unified-signatures": [2],
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      0,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [0],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      0,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "expression",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      0,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-a11y/alt-text": [2],
+    "jsx-a11y/anchor-ambiguous-text": [0],
+    "jsx-a11y/anchor-has-content": [2],
+    "jsx-a11y/anchor-is-valid": [2],
+    "jsx-a11y/aria-activedescendant-has-tabindex": [2],
+    "jsx-a11y/aria-props": [2],
+    "jsx-a11y/aria-proptypes": [2],
+    "jsx-a11y/aria-role": [2],
+    "jsx-a11y/aria-unsupported-elements": [2],
+    "jsx-a11y/autocomplete-valid": [2],
+    "jsx-a11y/click-events-have-key-events": [2],
+    "jsx-a11y/control-has-associated-label": [
+      0,
+      {
+        "ignoreElements": [
+          "audio",
+          "canvas",
+          "embed",
+          "input",
+          "textarea",
+          "tr",
+          "video"
+        ],
+        "ignoreRoles": [
+          "grid",
+          "listbox",
+          "menu",
+          "menubar",
+          "radiogroup",
+          "row",
+          "tablist",
+          "toolbar",
+          "tree",
+          "treegrid"
+        ],
+        "includeRoles": ["alert", "dialog"]
+      }
+    ],
+    "jsx-a11y/heading-has-content": [2],
+    "jsx-a11y/html-has-lang": [2],
+    "jsx-a11y/iframe-has-title": [2],
+    "jsx-a11y/img-redundant-alt": [2],
+    "jsx-a11y/interactive-supports-focus": [
+      2,
+      {
+        "tabbable": [
+          "button",
+          "checkbox",
+          "link",
+          "progressbar",
+          "searchbox",
+          "slider",
+          "spinbutton",
+          "switch",
+          "textbox"
+        ]
+      }
+    ],
+    "jsx-a11y/label-has-associated-control": [2],
+    "jsx-a11y/label-has-for": [0],
+    "jsx-a11y/media-has-caption": [2],
+    "jsx-a11y/mouse-events-have-key-events": [2],
+    "jsx-a11y/no-access-key": [2],
+    "jsx-a11y/no-autofocus": [2],
+    "jsx-a11y/no-distracting-elements": [2],
+    "jsx-a11y/no-interactive-element-to-noninteractive-role": [
+      2,
+      {
+        "tr": ["none", "presentation"],
+        "canvas": ["img"]
+      }
+    ],
+    "jsx-a11y/no-noninteractive-element-interactions": [
+      2,
+      {
+        "body": ["onError", "onLoad"],
+        "iframe": ["onError", "onLoad"],
+        "img": ["onError", "onLoad"]
+      }
+    ],
+    "jsx-a11y/no-noninteractive-element-to-interactive-role": [
+      2,
+      {
+        "ul": [
+          "listbox",
+          "menu",
+          "menubar",
+          "radiogroup",
+          "tablist",
+          "tree",
+          "treegrid"
+        ],
+        "ol": [
+          "listbox",
+          "menu",
+          "menubar",
+          "radiogroup",
+          "tablist",
+          "tree",
+          "treegrid"
+        ],
+        "li": [
+          "menuitem",
+          "menuitemradio",
+          "menuitemcheckbox",
+          "option",
+          "row",
+          "tab",
+          "treeitem"
+        ],
+        "table": ["grid"],
+        "td": ["gridcell"],
+        "fieldset": ["radiogroup", "presentation"]
+      }
+    ],
+    "jsx-a11y/no-noninteractive-tabindex": [
+      2,
+      {
+        "tags": [],
+        "roles": ["tabpanel"],
+        "allowExpressionValues": true
+      }
+    ],
+    "jsx-a11y/no-redundant-roles": [2],
+    "jsx-a11y/no-static-element-interactions": [
+      2,
+      {
+        "allowExpressionValues": true,
+        "handlers": [
+          "onClick",
+          "onMouseDown",
+          "onMouseUp",
+          "onKeyPress",
+          "onKeyDown",
+          "onKeyUp"
+        ]
+      }
+    ],
+    "jsx-a11y/role-has-required-aria-props": [2],
+    "jsx-a11y/role-supports-aria-props": [2],
+    "jsx-a11y/scope": [2],
+    "jsx-a11y/tabindex-no-positive": [2],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [0, 5],
+    "max-len": [0],
+    "max-lines": [
+      1,
+      {
+        "max": 1400,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-nested-callbacks": [0, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [0],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [0],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [0],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [0],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      0,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [0],
+    "no-dupe-class-members": [0],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [0],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [0],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [0],
+    "no-import-assign": [0],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [0],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [0],
+    "no-new-symbol": [0],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [0],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-only-tests/no-only-tests": [2],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      0,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-return-await": [0],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [0],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [0],
+    "no-throw-literal": [0],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      0,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [0],
+    "no-unreachable-loop": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      0,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [0],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [2],
+    "no-whitespace-before-property": [0],
+    "no-with": [0],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      0,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-arrow/prefer-arrow-functions": [
+      1,
+      {
+        "disallowPrototype": false,
+        "singleReturnOnly": false,
+        "classPropertiesAllowed": false
+      }
+    ],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      0,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [2],
+    "prefer-spread": [2],
+    "quote-props": [0],
+    "quotes": [0],
+    "react-hooks/config": [2],
+    "react-hooks/error-boundaries": [0],
+    "react-hooks/exhaustive-deps": [0],
+    "react-hooks/gating": [2],
+    "react-hooks/globals": [0],
+    "react-hooks/immutability": [0],
+    "react-hooks/incompatible-library": [1],
+    "react-hooks/preserve-manual-memoization": [2],
+    "react-hooks/purity": [0],
+    "react-hooks/refs": [0],
+    "react-hooks/rules-of-hooks": [0],
+    "react-hooks/set-state-in-effect": [0],
+    "react-hooks/set-state-in-render": [0],
+    "react-hooks/static-components": [0],
+    "react-hooks/unsupported-syntax": [0],
+    "react-hooks/use-memo": [0],
+    "react-refresh/only-export-components": [
+      0,
+      {
+        "allowConstantExport": true,
+        "allowExportNames": [
+          "getServerSideProps",
+          "meta",
+          "links",
+          "headers",
+          "loader",
+          "action"
+        ]
+      }
+    ],
+    "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": [1],
+    "react-you-might-not-need-an-effect/no-chain-state-updates": [1],
+    "react-you-might-not-need-an-effect/no-derived-state": [1],
+    "react-you-might-not-need-an-effect/no-event-handler": [1],
+    "react-you-might-not-need-an-effect/no-external-store-subscription": [1],
+    "react-you-might-not-need-an-effect/no-initialize-state": [1],
+    "react-you-might-not-need-an-effect/no-pass-data-to-parent": [1],
+    "react-you-might-not-need-an-effect/no-pass-live-state-to-parent": [1],
+    "react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change": [1],
+    "react/button-has-type": [0],
+    "react/default-props-match-prop-types": [1],
+    "react/destructuring-assignment": [0],
+    "react/display-name": [0],
+    "react/forbid-foreign-prop-types": [1],
+    "react/forbid-prop-types": [
+      1,
+      {
+        "checkChildContextTypes": true,
+        "checkContextTypes": true
+      }
+    ],
+    "react/forward-ref-uses-ref": [0],
+    "react/hook-use-state": [0],
+    "react/iframe-missing-sandbox": [0],
+    "react/jsx-boolean-value": [1, "never"],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-brace-presence": [1, "never"],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-filename-extension": [
+      1,
+      {
+        "extensions": [".jsx", ".tsx"]
+      }
+    ],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-fragments": [0],
+    "react/jsx-handler-names": [
+      1,
+      {
+        "eventHandlerPrefix": "handle",
+        "eventHandlerPropPrefix": "on"
+      }
+    ],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-key": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-no-comment-textnodes": [0],
+    "react/jsx-no-constructed-context-values": [0],
+    "react/jsx-no-duplicate-props": [2],
+    "react/jsx-no-leaked-render": [0],
+    "react/jsx-no-script-url": [0],
+    "react/jsx-no-target-blank": [0],
+    "react/jsx-no-undef": [1],
+    "react/jsx-no-useless-fragment": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-pascal-case": [1],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-props-no-spread-multi": [1],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-uses-react": [0],
+    "react/jsx-uses-vars": [2],
+    "react/jsx-wrap-multilines": [0],
+    "react/no-access-state-in-setstate": [0],
+    "react/no-array-index-key": [0],
+    "react/no-children-prop": [0],
+    "react/no-danger": [0],
+    "react/no-danger-with-children": [0],
+    "react/no-deprecated": [0],
+    "react/no-did-mount-set-state": [0],
+    "react/no-did-update-set-state": [0],
+    "react/no-direct-mutation-state": [0],
+    "react/no-find-dom-node": [0],
+    "react/no-invalid-html-attribute": [1],
+    "react/no-is-mounted": [2],
+    "react/no-namespace": [0],
+    "react/no-object-type-as-default-prop": [0],
+    "react/no-redundant-should-component-update": [1],
+    "react/no-render-return-value": [0],
+    "react/no-string-refs": [0],
+    "react/no-this-in-sfc": [1],
+    "react/no-typos": [1],
+    "react/no-unescaped-entities": [2],
+    "react/no-unknown-property": [0],
+    "react/no-unsafe": [0],
+    "react/no-unstable-nested-components": [0],
+    "react/no-unused-class-component-members": [0],
+    "react/no-unused-prop-types": [1],
+    "react/no-unused-state": [0],
+    "react/no-will-update-set-state": [0],
+    "react/prefer-es6-class": [1],
+    "react/prefer-stateless-function": [
+      1,
+      {
+        "ignorePureComponents": true
+      }
+    ],
+    "react/prop-types": [0],
+    "react/react-in-jsx-scope": [0],
+    "react/require-render-return": [2],
+    "react/self-closing-comp": [1],
+    "react/style-prop-object": [1],
+    "react/void-dom-elements-no-children": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-await": [0],
+    "require-yield": [0],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [0],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  }
+}

--- a/eslint/__snapshots__/typescript.json
+++ b/eslint/__snapshots__/typescript.json
@@ -1,0 +1,4739 @@
+{
+  "main.ts": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/adjacent-overload-signatures": [2],
+    "@typescript-eslint/array-type": [
+      1,
+      {
+        "default": "generic"
+      }
+    ],
+    "@typescript-eslint/await-thenable": [2],
+    "@typescript-eslint/ban-ts-comment": [
+      1,
+      {
+        "ts-expect-error": "allow-with-description"
+      }
+    ],
+    "@typescript-eslint/ban-tslint-comment": [2],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/class-literal-property-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/consistent-generic-constructors": [2],
+    "@typescript-eslint/consistent-indexed-object-style": [2],
+    "@typescript-eslint/consistent-type-assertions": [2],
+    "@typescript-eslint/consistent-type-definitions": [1, "type"],
+    "@typescript-eslint/dot-notation": [
+      2,
+      {
+        "allowIndexSignaturePropertyAccess": false,
+        "allowKeywords": true,
+        "allowPattern": "",
+        "allowPrivateClassPropertyAccess": false,
+        "allowProtectedClassPropertyAccess": false
+      }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      1,
+      {
+        "accessibility": "no-public",
+        "overrides": {
+          "parameterProperties": "explicit"
+        }
+      }
+    ],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/method-signature-style": [1, "property"],
+    "@typescript-eslint/naming-convention": [
+      1,
+      {
+        "selector": "default",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "parameter",
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "method",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "variable",
+        "modifiers": ["destructured"],
+        "format": null
+      },
+      {
+        "selector": [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember"
+        ],
+        "modifiers": ["requiresQuotes"],
+        "format": null
+      },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "variable"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "function"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameter"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "property"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameterProperty"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "method"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "accessor"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enumMember"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "class"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "interface"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeAlias"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enum"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeParameter"
+      }
+    ],
+    "@typescript-eslint/no-array-constructor": [2],
+    "@typescript-eslint/no-array-delete": [2],
+    "@typescript-eslint/no-base-to-string": [2],
+    "@typescript-eslint/no-confusing-non-null-assertion": [2],
+    "@typescript-eslint/no-confusing-void-expression": [
+      0,
+      {
+        "ignoreArrowShorthand": true,
+        "ignoreVoidOperator": true
+      }
+    ],
+    "@typescript-eslint/no-deprecated": [2],
+    "@typescript-eslint/no-duplicate-enum-values": [2],
+    "@typescript-eslint/no-duplicate-type-constituents": [2],
+    "@typescript-eslint/no-dynamic-delete": [2],
+    "@typescript-eslint/no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "@typescript-eslint/no-empty-interface": [0],
+    "@typescript-eslint/no-empty-object-type": [2],
+    "@typescript-eslint/no-explicit-any": [
+      0,
+      {
+        "fixToUnknown": false,
+        "ignoreRestArgs": true
+      }
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [2],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/no-extraneous-class": [2],
+    "@typescript-eslint/no-floating-promises": [2],
+    "@typescript-eslint/no-for-in-array": [2],
+    "@typescript-eslint/no-implied-eval": [2],
+    "@typescript-eslint/no-inferrable-types": [2],
+    "@typescript-eslint/no-invalid-void-type": [2],
+    "@typescript-eslint/no-meaningless-void-operator": [2],
+    "@typescript-eslint/no-misused-new": [2],
+    "@typescript-eslint/no-misused-promises": [2],
+    "@typescript-eslint/no-misused-spread": [2],
+    "@typescript-eslint/no-mixed-enums": [2],
+    "@typescript-eslint/no-namespace": [2],
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [2],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [2],
+    "@typescript-eslint/no-non-null-assertion": [0],
+    "@typescript-eslint/no-redundant-type-constituents": [2],
+    "@typescript-eslint/no-require-imports": [2],
+    "@typescript-eslint/no-this-alias": [2],
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": [0],
+    "@typescript-eslint/no-unnecessary-condition": [
+      1,
+      {
+        "allowConstantLoopConditions": true
+      }
+    ],
+    "@typescript-eslint/no-unnecessary-qualifier": [1],
+    "@typescript-eslint/no-unnecessary-template-expression": [2],
+    "@typescript-eslint/no-unnecessary-type-arguments": [2],
+    "@typescript-eslint/no-unnecessary-type-assertion": [2],
+    "@typescript-eslint/no-unnecessary-type-constraint": [2],
+    "@typescript-eslint/no-unnecessary-type-conversion": [2],
+    "@typescript-eslint/no-unnecessary-type-parameters": [2],
+    "@typescript-eslint/no-unsafe-argument": [0],
+    "@typescript-eslint/no-unsafe-assignment": [0],
+    "@typescript-eslint/no-unsafe-call": [0],
+    "@typescript-eslint/no-unsafe-declaration-merging": [2],
+    "@typescript-eslint/no-unsafe-enum-comparison": [2],
+    "@typescript-eslint/no-unsafe-function-type": [2],
+    "@typescript-eslint/no-unsafe-member-access": [0],
+    "@typescript-eslint/no-unsafe-return": [2],
+    "@typescript-eslint/no-unsafe-unary-minus": [2],
+    "@typescript-eslint/no-unused-expressions": [
+      1,
+      {
+        "allowShortCircuit": true,
+        "allowTaggedTemplates": false,
+        "allowTernary": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "@typescript-eslint/no-useless-constructor": [2],
+    "@typescript-eslint/no-useless-default-assignment": [2],
+    "@typescript-eslint/no-wrapper-object-types": [2],
+    "@typescript-eslint/non-nullable-type-assertion-style": [2],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/only-throw-error": [2],
+    "@typescript-eslint/prefer-as-const": [2],
+    "@typescript-eslint/prefer-find": [2],
+    "@typescript-eslint/prefer-for-of": [2],
+    "@typescript-eslint/prefer-function-type": [2],
+    "@typescript-eslint/prefer-includes": [2],
+    "@typescript-eslint/prefer-literal-enum-member": [2],
+    "@typescript-eslint/prefer-namespace-keyword": [2],
+    "@typescript-eslint/prefer-nullish-coalescing": [2],
+    "@typescript-eslint/prefer-optional-chain": [2],
+    "@typescript-eslint/prefer-promise-reject-errors": [2],
+    "@typescript-eslint/prefer-reduce-type-parameter": [2],
+    "@typescript-eslint/prefer-regexp-exec": [2],
+    "@typescript-eslint/prefer-return-this-type": [2],
+    "@typescript-eslint/prefer-string-starts-ends-with": [2],
+    "@typescript-eslint/promise-function-async": [
+      1,
+      {
+        "allowAny": true,
+        "allowedPromiseNames": [],
+        "checkArrowFunctions": true,
+        "checkFunctionDeclarations": true,
+        "checkFunctionExpressions": true,
+        "checkMethodDeclarations": true
+      }
+    ],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/related-getter-setter-pairs": [2],
+    "@typescript-eslint/require-await": [0],
+    "@typescript-eslint/restrict-plus-operands": [
+      2,
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": true,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      0,
+      {
+        "allowBoolean": false,
+        "allowNullable": false,
+        "allowNumber": true
+      }
+    ],
+    "@typescript-eslint/return-await": [1, "in-try-catch"],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/switch-exhaustiveness-check": [
+      1,
+      {
+        "considerDefaultExhaustiveForUnions": true
+      }
+    ],
+    "@typescript-eslint/triple-slash-reference": [2],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "@typescript-eslint/unbound-method": [2],
+    "@typescript-eslint/unified-signatures": [2],
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      0,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [0],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      0,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "expression",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      0,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [1, 5],
+    "max-len": [0],
+    "max-lines": [
+      1,
+      {
+        "max": 1400,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-nested-callbacks": [1, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [0],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [1],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [0],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [0],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      2,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [0],
+    "no-dupe-class-members": [0],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [0],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [0],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [0],
+    "no-import-assign": [0],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [1],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [0],
+    "no-new-symbol": [0],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [0],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      0,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-return-await": [0],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [0],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [0],
+    "no-throw-literal": [0],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      0,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [0],
+    "no-unreachable-loop": [
+      1,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      0,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [0],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [2],
+    "no-whitespace-before-property": [0],
+    "no-with": [0],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      1,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-arrow/prefer-arrow-functions": [
+      1,
+      {
+        "disallowPrototype": false,
+        "singleReturnOnly": false,
+        "classPropertiesAllowed": false
+      }
+    ],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      0,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [2],
+    "prefer-spread": [2],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-await": [0],
+    "require-yield": [2],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [2],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  },
+  "main.d.ts": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/adjacent-overload-signatures": [2],
+    "@typescript-eslint/array-type": [
+      1,
+      {
+        "default": "generic"
+      }
+    ],
+    "@typescript-eslint/await-thenable": [2],
+    "@typescript-eslint/ban-ts-comment": [
+      1,
+      {
+        "ts-expect-error": "allow-with-description"
+      }
+    ],
+    "@typescript-eslint/ban-tslint-comment": [2],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/class-literal-property-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/consistent-generic-constructors": [2],
+    "@typescript-eslint/consistent-indexed-object-style": [2],
+    "@typescript-eslint/consistent-type-assertions": [2],
+    "@typescript-eslint/consistent-type-definitions": [0, "type"],
+    "@typescript-eslint/dot-notation": [
+      2,
+      {
+        "allowIndexSignaturePropertyAccess": false,
+        "allowKeywords": true,
+        "allowPattern": "",
+        "allowPrivateClassPropertyAccess": false,
+        "allowProtectedClassPropertyAccess": false
+      }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      1,
+      {
+        "accessibility": "no-public",
+        "overrides": {
+          "parameterProperties": "explicit"
+        }
+      }
+    ],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/method-signature-style": [0, "property"],
+    "@typescript-eslint/naming-convention": [
+      0,
+      {
+        "selector": "default",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "parameter",
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "method",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "variable",
+        "modifiers": ["destructured"],
+        "format": null
+      },
+      {
+        "selector": [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember"
+        ],
+        "modifiers": ["requiresQuotes"],
+        "format": null
+      },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "variable"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "function"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameter"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "property"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameterProperty"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "method"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "accessor"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enumMember"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "class"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "interface"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeAlias"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enum"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeParameter"
+      }
+    ],
+    "@typescript-eslint/no-array-constructor": [2],
+    "@typescript-eslint/no-array-delete": [2],
+    "@typescript-eslint/no-base-to-string": [2],
+    "@typescript-eslint/no-confusing-non-null-assertion": [2],
+    "@typescript-eslint/no-confusing-void-expression": [
+      0,
+      {
+        "ignoreArrowShorthand": true,
+        "ignoreVoidOperator": true
+      }
+    ],
+    "@typescript-eslint/no-deprecated": [2],
+    "@typescript-eslint/no-duplicate-enum-values": [2],
+    "@typescript-eslint/no-duplicate-type-constituents": [2],
+    "@typescript-eslint/no-dynamic-delete": [2],
+    "@typescript-eslint/no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "@typescript-eslint/no-empty-interface": [0],
+    "@typescript-eslint/no-empty-object-type": [2],
+    "@typescript-eslint/no-explicit-any": [
+      0,
+      {
+        "fixToUnknown": false,
+        "ignoreRestArgs": true
+      }
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [2],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/no-extraneous-class": [2],
+    "@typescript-eslint/no-floating-promises": [2],
+    "@typescript-eslint/no-for-in-array": [2],
+    "@typescript-eslint/no-implied-eval": [2],
+    "@typescript-eslint/no-inferrable-types": [2],
+    "@typescript-eslint/no-invalid-void-type": [2],
+    "@typescript-eslint/no-meaningless-void-operator": [2],
+    "@typescript-eslint/no-misused-new": [2],
+    "@typescript-eslint/no-misused-promises": [2],
+    "@typescript-eslint/no-misused-spread": [2],
+    "@typescript-eslint/no-mixed-enums": [2],
+    "@typescript-eslint/no-namespace": [2],
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [2],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [2],
+    "@typescript-eslint/no-non-null-assertion": [0],
+    "@typescript-eslint/no-redundant-type-constituents": [2],
+    "@typescript-eslint/no-require-imports": [2],
+    "@typescript-eslint/no-this-alias": [2],
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": [0],
+    "@typescript-eslint/no-unnecessary-condition": [
+      1,
+      {
+        "allowConstantLoopConditions": true
+      }
+    ],
+    "@typescript-eslint/no-unnecessary-qualifier": [1],
+    "@typescript-eslint/no-unnecessary-template-expression": [2],
+    "@typescript-eslint/no-unnecessary-type-arguments": [2],
+    "@typescript-eslint/no-unnecessary-type-assertion": [2],
+    "@typescript-eslint/no-unnecessary-type-constraint": [2],
+    "@typescript-eslint/no-unnecessary-type-conversion": [2],
+    "@typescript-eslint/no-unnecessary-type-parameters": [2],
+    "@typescript-eslint/no-unsafe-argument": [0],
+    "@typescript-eslint/no-unsafe-assignment": [0],
+    "@typescript-eslint/no-unsafe-call": [0],
+    "@typescript-eslint/no-unsafe-declaration-merging": [2],
+    "@typescript-eslint/no-unsafe-enum-comparison": [2],
+    "@typescript-eslint/no-unsafe-function-type": [2],
+    "@typescript-eslint/no-unsafe-member-access": [0],
+    "@typescript-eslint/no-unsafe-return": [2],
+    "@typescript-eslint/no-unsafe-unary-minus": [2],
+    "@typescript-eslint/no-unused-expressions": [
+      1,
+      {
+        "allowShortCircuit": true,
+        "allowTaggedTemplates": false,
+        "allowTernary": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "@typescript-eslint/no-useless-constructor": [2],
+    "@typescript-eslint/no-useless-default-assignment": [2],
+    "@typescript-eslint/no-wrapper-object-types": [2],
+    "@typescript-eslint/non-nullable-type-assertion-style": [2],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/only-throw-error": [2],
+    "@typescript-eslint/prefer-as-const": [2],
+    "@typescript-eslint/prefer-find": [2],
+    "@typescript-eslint/prefer-for-of": [2],
+    "@typescript-eslint/prefer-function-type": [2],
+    "@typescript-eslint/prefer-includes": [2],
+    "@typescript-eslint/prefer-literal-enum-member": [2],
+    "@typescript-eslint/prefer-namespace-keyword": [2],
+    "@typescript-eslint/prefer-nullish-coalescing": [2],
+    "@typescript-eslint/prefer-optional-chain": [2],
+    "@typescript-eslint/prefer-promise-reject-errors": [2],
+    "@typescript-eslint/prefer-reduce-type-parameter": [2],
+    "@typescript-eslint/prefer-regexp-exec": [2],
+    "@typescript-eslint/prefer-return-this-type": [2],
+    "@typescript-eslint/prefer-string-starts-ends-with": [2],
+    "@typescript-eslint/promise-function-async": [
+      1,
+      {
+        "allowAny": true,
+        "allowedPromiseNames": [],
+        "checkArrowFunctions": true,
+        "checkFunctionDeclarations": true,
+        "checkFunctionExpressions": true,
+        "checkMethodDeclarations": true
+      }
+    ],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/related-getter-setter-pairs": [2],
+    "@typescript-eslint/require-await": [0],
+    "@typescript-eslint/restrict-plus-operands": [
+      2,
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": true,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      0,
+      {
+        "allowBoolean": false,
+        "allowNullable": false,
+        "allowNumber": true
+      }
+    ],
+    "@typescript-eslint/return-await": [1, "in-try-catch"],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/switch-exhaustiveness-check": [
+      1,
+      {
+        "considerDefaultExhaustiveForUnions": true
+      }
+    ],
+    "@typescript-eslint/triple-slash-reference": [2],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "@typescript-eslint/unbound-method": [2],
+    "@typescript-eslint/unified-signatures": [2],
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      0,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [0],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      0,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "expression",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      0,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "import/no-default-export": [0],
+    "import/no-unassigned-import": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [1, 5],
+    "max-len": [0],
+    "max-lines": [
+      1,
+      {
+        "max": 1400,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-nested-callbacks": [1, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [0],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [1],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [0],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [0],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      2,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [0],
+    "no-dupe-class-members": [0],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [0],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [0],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [0],
+    "no-import-assign": [0],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [1],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [0],
+    "no-new-symbol": [0],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [0],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      0,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-return-await": [0],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [0],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [0],
+    "no-throw-literal": [0],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      0,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [0],
+    "no-unreachable-loop": [
+      1,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      0,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [0],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [2],
+    "no-whitespace-before-property": [0],
+    "no-with": [0],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      1,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-arrow/prefer-arrow-functions": [
+      1,
+      {
+        "disallowPrototype": false,
+        "singleReturnOnly": false,
+        "classPropertiesAllowed": false
+      }
+    ],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      0,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [2],
+    "prefer-spread": [2],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-await": [0],
+    "require-yield": [2],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [2],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  },
+  "main.test.ts": {
+    "@babel/object-curly-spacing": [0],
+    "@babel/semi": [0],
+    "@stylistic/array-bracket-newline": [0],
+    "@stylistic/array-bracket-spacing": [0],
+    "@stylistic/array-element-newline": [0],
+    "@stylistic/arrow-parens": [0],
+    "@stylistic/arrow-spacing": [0],
+    "@stylistic/block-spacing": [0],
+    "@stylistic/brace-style": [0],
+    "@stylistic/comma-dangle": [0],
+    "@stylistic/comma-spacing": [0],
+    "@stylistic/comma-style": [0],
+    "@stylistic/computed-property-spacing": [0],
+    "@stylistic/dot-location": [0],
+    "@stylistic/eol-last": [0],
+    "@stylistic/func-call-spacing": [0],
+    "@stylistic/function-call-argument-newline": [0],
+    "@stylistic/function-call-spacing": [0],
+    "@stylistic/function-paren-newline": [0],
+    "@stylistic/generator-star-spacing": [0],
+    "@stylistic/implicit-arrow-linebreak": [0],
+    "@stylistic/indent": [0],
+    "@stylistic/indent-binary-ops": [0],
+    "@stylistic/js/array-bracket-newline": [0],
+    "@stylistic/js/array-bracket-spacing": [0],
+    "@stylistic/js/array-element-newline": [0],
+    "@stylistic/js/arrow-parens": [0],
+    "@stylistic/js/arrow-spacing": [0],
+    "@stylistic/js/block-spacing": [0],
+    "@stylistic/js/brace-style": [0],
+    "@stylistic/js/comma-dangle": [0],
+    "@stylistic/js/comma-spacing": [0],
+    "@stylistic/js/comma-style": [0],
+    "@stylistic/js/computed-property-spacing": [0],
+    "@stylistic/js/dot-location": [0],
+    "@stylistic/js/eol-last": [0],
+    "@stylistic/js/func-call-spacing": [0],
+    "@stylistic/js/function-call-argument-newline": [0],
+    "@stylistic/js/function-call-spacing": [0],
+    "@stylistic/js/function-paren-newline": [0],
+    "@stylistic/js/generator-star-spacing": [0],
+    "@stylistic/js/implicit-arrow-linebreak": [0],
+    "@stylistic/js/indent": [0],
+    "@stylistic/js/jsx-quotes": [0],
+    "@stylistic/js/key-spacing": [0],
+    "@stylistic/js/keyword-spacing": [0],
+    "@stylistic/js/linebreak-style": [0],
+    "@stylistic/js/lines-around-comment": [0],
+    "@stylistic/js/max-len": [0],
+    "@stylistic/js/max-statements-per-line": [0],
+    "@stylistic/js/multiline-ternary": [0],
+    "@stylistic/js/new-parens": [0],
+    "@stylistic/js/newline-per-chained-call": [0],
+    "@stylistic/js/no-confusing-arrow": [0],
+    "@stylistic/js/no-extra-parens": [0],
+    "@stylistic/js/no-extra-semi": [0],
+    "@stylistic/js/no-floating-decimal": [0],
+    "@stylistic/js/no-mixed-operators": [0],
+    "@stylistic/js/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/js/no-multi-spaces": [0],
+    "@stylistic/js/no-multiple-empty-lines": [0],
+    "@stylistic/js/no-tabs": [0],
+    "@stylistic/js/no-trailing-spaces": [0],
+    "@stylistic/js/no-whitespace-before-property": [0],
+    "@stylistic/js/nonblock-statement-body-position": [0],
+    "@stylistic/js/object-curly-newline": [0],
+    "@stylistic/js/object-curly-spacing": [0],
+    "@stylistic/js/object-property-newline": [0],
+    "@stylistic/js/one-var-declaration-per-line": [0],
+    "@stylistic/js/operator-linebreak": [0],
+    "@stylistic/js/padded-blocks": [0],
+    "@stylistic/js/quote-props": [0],
+    "@stylistic/js/quotes": [0],
+    "@stylistic/js/rest-spread-spacing": [0],
+    "@stylistic/js/semi": [0],
+    "@stylistic/js/semi-spacing": [0],
+    "@stylistic/js/semi-style": [0],
+    "@stylistic/js/space-before-blocks": [0],
+    "@stylistic/js/space-before-function-paren": [0],
+    "@stylistic/js/space-in-parens": [0],
+    "@stylistic/js/space-infix-ops": [0],
+    "@stylistic/js/space-unary-ops": [0],
+    "@stylistic/js/switch-colon-spacing": [0],
+    "@stylistic/js/template-curly-spacing": [0],
+    "@stylistic/js/template-tag-spacing": [0],
+    "@stylistic/js/wrap-iife": [0],
+    "@stylistic/js/wrap-regex": [0],
+    "@stylistic/js/yield-star-spacing": [0],
+    "@stylistic/jsx-child-element-spacing": [0],
+    "@stylistic/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx-closing-tag-location": [0],
+    "@stylistic/jsx-curly-newline": [0],
+    "@stylistic/jsx-curly-spacing": [0],
+    "@stylistic/jsx-equals-spacing": [0],
+    "@stylistic/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx-indent": [0],
+    "@stylistic/jsx-indent-props": [0],
+    "@stylistic/jsx-max-props-per-line": [0],
+    "@stylistic/jsx-newline": [0],
+    "@stylistic/jsx-one-expression-per-line": [0],
+    "@stylistic/jsx-props-no-multi-spaces": [0],
+    "@stylistic/jsx-quotes": [0],
+    "@stylistic/jsx-tag-spacing": [0],
+    "@stylistic/jsx-wrap-multilines": [0],
+    "@stylistic/jsx/jsx-child-element-spacing": [0],
+    "@stylistic/jsx/jsx-closing-bracket-location": [0],
+    "@stylistic/jsx/jsx-closing-tag-location": [0],
+    "@stylistic/jsx/jsx-curly-newline": [0],
+    "@stylistic/jsx/jsx-curly-spacing": [0],
+    "@stylistic/jsx/jsx-equals-spacing": [0],
+    "@stylistic/jsx/jsx-first-prop-new-line": [0],
+    "@stylistic/jsx/jsx-indent": [0],
+    "@stylistic/jsx/jsx-indent-props": [0],
+    "@stylistic/jsx/jsx-max-props-per-line": [0],
+    "@stylistic/key-spacing": [0],
+    "@stylistic/keyword-spacing": [0],
+    "@stylistic/linebreak-style": [0],
+    "@stylistic/lines-around-comment": [0],
+    "@stylistic/max-len": [0],
+    "@stylistic/max-statements-per-line": [0],
+    "@stylistic/member-delimiter-style": [0],
+    "@stylistic/multiline-ternary": [0],
+    "@stylistic/new-parens": [0],
+    "@stylistic/newline-per-chained-call": [0],
+    "@stylistic/no-confusing-arrow": [0],
+    "@stylistic/no-extra-parens": [0],
+    "@stylistic/no-extra-semi": [0],
+    "@stylistic/no-floating-decimal": [0],
+    "@stylistic/no-mixed-operators": [0],
+    "@stylistic/no-mixed-spaces-and-tabs": [0],
+    "@stylistic/no-multi-spaces": [0],
+    "@stylistic/no-multiple-empty-lines": [0],
+    "@stylistic/no-tabs": [0],
+    "@stylistic/no-trailing-spaces": [0],
+    "@stylistic/no-whitespace-before-property": [0],
+    "@stylistic/nonblock-statement-body-position": [0],
+    "@stylistic/object-curly-newline": [0],
+    "@stylistic/object-curly-spacing": [0],
+    "@stylistic/object-property-newline": [0],
+    "@stylistic/one-var-declaration-per-line": [0],
+    "@stylistic/operator-linebreak": [0],
+    "@stylistic/padded-blocks": [0],
+    "@stylistic/quote-props": [0],
+    "@stylistic/quotes": [0],
+    "@stylistic/rest-spread-spacing": [0],
+    "@stylistic/semi": [0],
+    "@stylistic/semi-spacing": [0],
+    "@stylistic/semi-style": [0],
+    "@stylistic/space-before-blocks": [0],
+    "@stylistic/space-before-function-paren": [0],
+    "@stylistic/space-in-parens": [0],
+    "@stylistic/space-infix-ops": [0],
+    "@stylistic/space-unary-ops": [0],
+    "@stylistic/switch-colon-spacing": [0],
+    "@stylistic/template-curly-spacing": [0],
+    "@stylistic/template-tag-spacing": [0],
+    "@stylistic/ts/block-spacing": [0],
+    "@stylistic/ts/brace-style": [0],
+    "@stylistic/ts/comma-dangle": [0],
+    "@stylistic/ts/comma-spacing": [0],
+    "@stylistic/ts/func-call-spacing": [0],
+    "@stylistic/ts/function-call-spacing": [0],
+    "@stylistic/ts/indent": [0],
+    "@stylistic/ts/key-spacing": [0],
+    "@stylistic/ts/keyword-spacing": [0],
+    "@stylistic/ts/lines-around-comment": [0],
+    "@stylistic/ts/member-delimiter-style": [0],
+    "@stylistic/ts/no-extra-parens": [0],
+    "@stylistic/ts/no-extra-semi": [0],
+    "@stylistic/ts/object-curly-spacing": [0],
+    "@stylistic/ts/quotes": [0],
+    "@stylistic/ts/semi": [0],
+    "@stylistic/ts/space-before-blocks": [0],
+    "@stylistic/ts/space-before-function-paren": [0],
+    "@stylistic/ts/space-infix-ops": [0],
+    "@stylistic/ts/type-annotation-spacing": [0],
+    "@stylistic/type-annotation-spacing": [0],
+    "@stylistic/type-generic-spacing": [0],
+    "@stylistic/type-named-tuple-spacing": [0],
+    "@stylistic/wrap-iife": [0],
+    "@stylistic/wrap-regex": [0],
+    "@stylistic/yield-star-spacing": [0],
+    "@typescript-eslint/adjacent-overload-signatures": [2],
+    "@typescript-eslint/array-type": [
+      1,
+      {
+        "default": "generic"
+      }
+    ],
+    "@typescript-eslint/await-thenable": [2],
+    "@typescript-eslint/ban-ts-comment": [
+      1,
+      {
+        "ts-expect-error": "allow-with-description"
+      }
+    ],
+    "@typescript-eslint/ban-tslint-comment": [2],
+    "@typescript-eslint/block-spacing": [0],
+    "@typescript-eslint/brace-style": [0],
+    "@typescript-eslint/class-literal-property-style": [0],
+    "@typescript-eslint/comma-dangle": [0],
+    "@typescript-eslint/comma-spacing": [0],
+    "@typescript-eslint/consistent-generic-constructors": [2],
+    "@typescript-eslint/consistent-indexed-object-style": [2],
+    "@typescript-eslint/consistent-type-assertions": [0],
+    "@typescript-eslint/consistent-type-definitions": [1, "type"],
+    "@typescript-eslint/dot-notation": [
+      2,
+      {
+        "allowIndexSignaturePropertyAccess": false,
+        "allowKeywords": true,
+        "allowPattern": "",
+        "allowPrivateClassPropertyAccess": false,
+        "allowProtectedClassPropertyAccess": false
+      }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      1,
+      {
+        "accessibility": "no-public",
+        "overrides": {
+          "parameterProperties": "explicit"
+        }
+      }
+    ],
+    "@typescript-eslint/func-call-spacing": [0],
+    "@typescript-eslint/indent": [0],
+    "@typescript-eslint/key-spacing": [0],
+    "@typescript-eslint/keyword-spacing": [0],
+    "@typescript-eslint/lines-around-comment": [0],
+    "@typescript-eslint/member-delimiter-style": [0],
+    "@typescript-eslint/method-signature-style": [1, "property"],
+    "@typescript-eslint/naming-convention": [
+      0,
+      {
+        "selector": "default",
+        "format": ["camelCase", "PascalCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "parameter",
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "method",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase"],
+        "leadingUnderscore": "allow",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "selector": "variable",
+        "modifiers": ["destructured"],
+        "format": null
+      },
+      {
+        "selector": [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember"
+        ],
+        "modifiers": ["requiresQuotes"],
+        "format": null
+      },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "variable"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "function"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameter"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "property"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "parameterProperty"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "method"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "accessor"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enumMember"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "class"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "interface"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeAlias"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "enum"
+      },
+      {
+        "filter": {
+          "match": true,
+          "regex": "^(__|UNSAFE_).+$"
+        },
+        "format": null,
+        "selector": "typeParameter"
+      }
+    ],
+    "@typescript-eslint/no-array-constructor": [2],
+    "@typescript-eslint/no-array-delete": [2],
+    "@typescript-eslint/no-base-to-string": [2],
+    "@typescript-eslint/no-confusing-non-null-assertion": [2],
+    "@typescript-eslint/no-confusing-void-expression": [
+      0,
+      {
+        "ignoreArrowShorthand": true,
+        "ignoreVoidOperator": true
+      }
+    ],
+    "@typescript-eslint/no-deprecated": [2],
+    "@typescript-eslint/no-duplicate-enum-values": [2],
+    "@typescript-eslint/no-duplicate-type-constituents": [2],
+    "@typescript-eslint/no-dynamic-delete": [2],
+    "@typescript-eslint/no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "@typescript-eslint/no-empty-interface": [0],
+    "@typescript-eslint/no-empty-object-type": [2],
+    "@typescript-eslint/no-explicit-any": [
+      0,
+      {
+        "fixToUnknown": false,
+        "ignoreRestArgs": true
+      }
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [2],
+    "@typescript-eslint/no-extra-parens": [0],
+    "@typescript-eslint/no-extra-semi": [0],
+    "@typescript-eslint/no-extraneous-class": [2],
+    "@typescript-eslint/no-floating-promises": [2],
+    "@typescript-eslint/no-for-in-array": [2],
+    "@typescript-eslint/no-implied-eval": [2],
+    "@typescript-eslint/no-inferrable-types": [2],
+    "@typescript-eslint/no-invalid-void-type": [2],
+    "@typescript-eslint/no-meaningless-void-operator": [2],
+    "@typescript-eslint/no-misused-new": [2],
+    "@typescript-eslint/no-misused-promises": [2],
+    "@typescript-eslint/no-misused-spread": [2],
+    "@typescript-eslint/no-mixed-enums": [2],
+    "@typescript-eslint/no-namespace": [2],
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [2],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [2],
+    "@typescript-eslint/no-non-null-assertion": [0],
+    "@typescript-eslint/no-redundant-type-constituents": [2],
+    "@typescript-eslint/no-require-imports": [2],
+    "@typescript-eslint/no-this-alias": [2],
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": [0],
+    "@typescript-eslint/no-unnecessary-condition": [
+      0,
+      {
+        "allowConstantLoopConditions": true
+      }
+    ],
+    "@typescript-eslint/no-unnecessary-qualifier": [1],
+    "@typescript-eslint/no-unnecessary-template-expression": [2],
+    "@typescript-eslint/no-unnecessary-type-arguments": [2],
+    "@typescript-eslint/no-unnecessary-type-assertion": [2],
+    "@typescript-eslint/no-unnecessary-type-constraint": [2],
+    "@typescript-eslint/no-unnecessary-type-conversion": [2],
+    "@typescript-eslint/no-unnecessary-type-parameters": [2],
+    "@typescript-eslint/no-unsafe-argument": [0],
+    "@typescript-eslint/no-unsafe-assignment": [0],
+    "@typescript-eslint/no-unsafe-call": [0],
+    "@typescript-eslint/no-unsafe-declaration-merging": [2],
+    "@typescript-eslint/no-unsafe-enum-comparison": [2],
+    "@typescript-eslint/no-unsafe-function-type": [2],
+    "@typescript-eslint/no-unsafe-member-access": [0],
+    "@typescript-eslint/no-unsafe-return": [0],
+    "@typescript-eslint/no-unsafe-unary-minus": [2],
+    "@typescript-eslint/no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTaggedTemplates": false,
+        "allowTernary": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      2,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "@typescript-eslint/no-useless-constructor": [2],
+    "@typescript-eslint/no-useless-default-assignment": [2],
+    "@typescript-eslint/no-wrapper-object-types": [2],
+    "@typescript-eslint/non-nullable-type-assertion-style": [2],
+    "@typescript-eslint/object-curly-spacing": [0],
+    "@typescript-eslint/only-throw-error": [2],
+    "@typescript-eslint/prefer-as-const": [2],
+    "@typescript-eslint/prefer-find": [2],
+    "@typescript-eslint/prefer-for-of": [2],
+    "@typescript-eslint/prefer-function-type": [2],
+    "@typescript-eslint/prefer-includes": [2],
+    "@typescript-eslint/prefer-literal-enum-member": [2],
+    "@typescript-eslint/prefer-namespace-keyword": [2],
+    "@typescript-eslint/prefer-nullish-coalescing": [2],
+    "@typescript-eslint/prefer-optional-chain": [2],
+    "@typescript-eslint/prefer-promise-reject-errors": [2],
+    "@typescript-eslint/prefer-reduce-type-parameter": [2],
+    "@typescript-eslint/prefer-regexp-exec": [2],
+    "@typescript-eslint/prefer-return-this-type": [2],
+    "@typescript-eslint/prefer-string-starts-ends-with": [2],
+    "@typescript-eslint/promise-function-async": [
+      0,
+      {
+        "allowAny": true,
+        "allowedPromiseNames": [],
+        "checkArrowFunctions": true,
+        "checkFunctionDeclarations": true,
+        "checkFunctionExpressions": true,
+        "checkMethodDeclarations": true
+      }
+    ],
+    "@typescript-eslint/quotes": [0],
+    "@typescript-eslint/related-getter-setter-pairs": [2],
+    "@typescript-eslint/require-await": [0],
+    "@typescript-eslint/restrict-plus-operands": [
+      2,
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": true,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      0,
+      {
+        "allowBoolean": false,
+        "allowNullable": false,
+        "allowNumber": true
+      }
+    ],
+    "@typescript-eslint/return-await": [1, "in-try-catch"],
+    "@typescript-eslint/semi": [0],
+    "@typescript-eslint/space-before-blocks": [0],
+    "@typescript-eslint/space-before-function-paren": [0],
+    "@typescript-eslint/space-infix-ops": [0],
+    "@typescript-eslint/switch-exhaustiveness-check": [
+      1,
+      {
+        "considerDefaultExhaustiveForUnions": true
+      }
+    ],
+    "@typescript-eslint/triple-slash-reference": [2],
+    "@typescript-eslint/type-annotation-spacing": [0],
+    "@typescript-eslint/unbound-method": [0],
+    "@typescript-eslint/unified-signatures": [2],
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": [0],
+    "accessor-pairs": [
+      1,
+      {
+        "enforceForTSTypes": false,
+        "enforceForClassMembers": true,
+        "getWithoutSet": false,
+        "setWithoutGet": true
+      }
+    ],
+    "array-bracket-newline": [0],
+    "array-bracket-spacing": [0],
+    "array-callback-return": [
+      1,
+      {
+        "allowImplicit": false,
+        "checkForEach": false,
+        "allowVoid": false
+      }
+    ],
+    "array-element-newline": [0],
+    "arrow-parens": [0],
+    "arrow-spacing": [0],
+    "babel/object-curly-spacing": [0],
+    "babel/quotes": [0],
+    "babel/semi": [0],
+    "block-scoped-var": [1],
+    "block-spacing": [0],
+    "brace-style": [0],
+    "camelcase": [
+      0,
+      {
+        "allow": ["^UNSAFE_"],
+        "ignoreDestructuring": false,
+        "ignoreGlobals": false,
+        "ignoreImports": false,
+        "properties": "always"
+      }
+    ],
+    "comma-dangle": [0],
+    "comma-spacing": [0],
+    "comma-style": [0],
+    "computed-property-spacing": [0],
+    "consistent-return": [
+      0,
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ],
+    "constructor-super": [0],
+    "curly": [0, "all"],
+    "dot-location": [0],
+    "dot-notation": [
+      0,
+      {
+        "allowKeywords": true,
+        "allowPattern": ""
+      }
+    ],
+    "eol-last": [0],
+    "eqeqeq": [
+      1,
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "flowtype/boolean-style": [0],
+    "flowtype/delimiter-dangle": [0],
+    "flowtype/generic-spacing": [0],
+    "flowtype/object-type-curly-spacing": [0],
+    "flowtype/object-type-delimiter": [0],
+    "flowtype/quotes": [0],
+    "flowtype/semi": [0],
+    "flowtype/space-after-type-colon": [0],
+    "flowtype/space-before-generic-bracket": [0],
+    "flowtype/space-before-type-colon": [0],
+    "flowtype/union-intersection-spacing": [0],
+    "for-direction": [2],
+    "func-call-spacing": [0],
+    "func-style": [
+      1,
+      "expression",
+      {
+        "allowArrowFunctions": false,
+        "allowTypeAnnotation": false,
+        "overrides": {}
+      }
+    ],
+    "function-call-argument-newline": [0],
+    "function-paren-newline": [0],
+    "generator-star": [0],
+    "generator-star-spacing": [0],
+    "getter-return": [
+      0,
+      {
+        "allowImplicit": false
+      }
+    ],
+    "grouped-accessor-pairs": [
+      1,
+      "setBeforeGet",
+      {
+        "enforceForTSTypes": false
+      }
+    ],
+    "implicit-arrow-linebreak": [0],
+    "indent": [0],
+    "indent-legacy": [0],
+    "jsx-quotes": [0],
+    "key-spacing": [0],
+    "keyword-spacing": [0],
+    "linebreak-style": [0],
+    "lines-around-comment": [0],
+    "max-depth": [0, 5],
+    "max-len": [0],
+    "max-lines": [
+      1,
+      {
+        "max": 1400,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-nested-callbacks": [0, 3],
+    "max-params": [
+      1,
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [0],
+    "multiline-ternary": [0],
+    "new-cap": [
+      1,
+      {
+        "capIsNew": true,
+        "capIsNewExceptions": [
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+          "BigInt"
+        ],
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "properties": true
+      }
+    ],
+    "new-parens": [0],
+    "newline-per-chained-call": [0],
+    "no-alert": [1],
+    "no-array-constructor": [0],
+    "no-arrow-condition": [0],
+    "no-async-promise-executor": [2],
+    "no-await-in-loop": [0],
+    "no-bitwise": [
+      1,
+      {
+        "allow": [],
+        "int32Hint": false
+      }
+    ],
+    "no-caller": [1],
+    "no-case-declarations": [2],
+    "no-class-assign": [0],
+    "no-comma-dangle": [0],
+    "no-compare-neg-zero": [2],
+    "no-cond-assign": [2, "except-parens"],
+    "no-confusing-arrow": [0],
+    "no-const-assign": [0],
+    "no-constant-binary-expression": [2],
+    "no-constant-condition": [
+      0,
+      {
+        "checkLoops": "allExceptWhileTrue"
+      }
+    ],
+    "no-constructor-return": [1],
+    "no-control-regex": [2],
+    "no-debugger": [2],
+    "no-delete-var": [2],
+    "no-dupe-args": [0],
+    "no-dupe-class-members": [0],
+    "no-dupe-else-if": [2],
+    "no-dupe-keys": [0],
+    "no-duplicate-case": [2],
+    "no-duplicate-imports": [
+      1,
+      {
+        "includeExports": false,
+        "allowSeparateTypeImports": false
+      }
+    ],
+    "no-else-return": [
+      1,
+      {
+        "allowElseIf": true
+      }
+    ],
+    "no-empty": [
+      2,
+      {
+        "allowEmptyCatch": false
+      }
+    ],
+    "no-empty-character-class": [2],
+    "no-empty-function": [
+      0,
+      {
+        "allow": []
+      }
+    ],
+    "no-empty-pattern": [
+      2,
+      {
+        "allowObjectPatternsAsParameters": false
+      }
+    ],
+    "no-empty-static-block": [2],
+    "no-eval": [
+      1,
+      {
+        "allowIndirect": false
+      }
+    ],
+    "no-ex-assign": [2],
+    "no-extend-native": [
+      1,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-extra-bind": [1],
+    "no-extra-boolean-cast": [2, {}],
+    "no-extra-label": [1],
+    "no-extra-parens": [0],
+    "no-extra-semi": [0],
+    "no-fallthrough": [
+      2,
+      {
+        "allowEmptyCase": false,
+        "reportUnusedFallthroughComment": false
+      }
+    ],
+    "no-floating-decimal": [0],
+    "no-func-assign": [0],
+    "no-global-assign": [
+      2,
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implicit-globals": [
+      1,
+      {
+        "lexicalBindings": false
+      }
+    ],
+    "no-implied-eval": [0],
+    "no-import-assign": [0],
+    "no-invalid-regexp": [2, {}],
+    "no-irregular-whitespace": [
+      2,
+      {
+        "skipComments": false,
+        "skipJSXText": false,
+        "skipRegExps": false,
+        "skipStrings": true,
+        "skipTemplates": false
+      }
+    ],
+    "no-iterator": [1],
+    "no-label-var": [1],
+    "no-labels": [
+      1,
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": [1],
+    "no-loss-of-precision": [2],
+    "no-misleading-character-class": [
+      2,
+      {
+        "allowEscape": false
+      }
+    ],
+    "no-mixed-operators": [0],
+    "no-mixed-spaces-and-tabs": [0],
+    "no-multi-spaces": [0],
+    "no-multi-str": [1],
+    "no-multiple-empty-lines": [0],
+    "no-negated-condition": [1],
+    "no-nested-ternary": [0],
+    "no-new": [0],
+    "no-new-func": [1],
+    "no-new-native-nonconstructor": [0],
+    "no-new-symbol": [0],
+    "no-new-wrappers": [1],
+    "no-nonoctal-decimal-escape": [2],
+    "no-obj-calls": [0],
+    "no-object-constructor": [1],
+    "no-octal": [2],
+    "no-octal-escape": [1],
+    "no-only-tests/no-only-tests": [2],
+    "no-promise-executor-return": [
+      1,
+      {
+        "allowVoid": false
+      }
+    ],
+    "no-proto": [1],
+    "no-prototype-builtins": [2],
+    "no-redeclare": [
+      0,
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-regex-spaces": [2],
+    "no-reserved-keys": [0],
+    "no-restricted-exports": [
+      1,
+      {
+        "restrictedNamedExports": ["then"]
+      }
+    ],
+    "no-restricted-globals": [1, "event"],
+    "no-restricted-syntax": [1, "WithStatement"],
+    "no-return-await": [0],
+    "no-script-url": [1],
+    "no-self-assign": [
+      2,
+      {
+        "props": true
+      }
+    ],
+    "no-self-compare": [1],
+    "no-sequences": [
+      1,
+      {
+        "allowInParentheses": true
+      }
+    ],
+    "no-setter-return": [0],
+    "no-shadow-restricted-names": [
+      2,
+      {
+        "reportGlobalThis": false
+      }
+    ],
+    "no-space-before-semi": [0],
+    "no-spaced-func": [0],
+    "no-sparse-arrays": [2],
+    "no-tabs": [0],
+    "no-template-curly-in-string": [1],
+    "no-this-before-super": [0],
+    "no-throw-literal": [0],
+    "no-trailing-spaces": [0],
+    "no-undef": [
+      0,
+      {
+        "typeof": false
+      }
+    ],
+    "no-undef-init": [1],
+    "no-unexpected-multiline": [0],
+    "no-unmodified-loop-condition": [1],
+    "no-unneeded-ternary": [
+      1,
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": [0],
+    "no-unreachable-loop": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": [2],
+    "no-unsafe-negation": [
+      0,
+      {
+        "enforceForOrderingRelations": false
+      }
+    ],
+    "no-unsafe-optional-chaining": [
+      2,
+      {
+        "disallowArithmeticOperators": false
+      }
+    ],
+    "no-unused-expressions": [
+      0,
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": false,
+        "enforceForJSX": false,
+        "ignoreDirectives": false
+      }
+    ],
+    "no-unused-labels": [2],
+    "no-unused-private-class-members": [2],
+    "no-unused-vars": [
+      0,
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "reportUsedIgnorePattern": false,
+        "ignoreRestSiblings": true
+      }
+    ],
+    "no-useless-assignment": [1],
+    "no-useless-backreference": [2],
+    "no-useless-call": [1],
+    "no-useless-catch": [2],
+    "no-useless-computed-key": [
+      1,
+      {
+        "enforceForClassMembers": true
+      }
+    ],
+    "no-useless-concat": [1],
+    "no-useless-constructor": [0],
+    "no-useless-escape": [
+      1,
+      {
+        "allowRegexCharacters": []
+      }
+    ],
+    "no-useless-rename": [
+      1,
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": [1],
+    "no-var": [2],
+    "no-whitespace-before-property": [0],
+    "no-with": [0],
+    "no-wrap-func": [0],
+    "nonblock-statement-body-position": [0],
+    "object-curly-newline": [0],
+    "object-curly-spacing": [0],
+    "object-property-newline": [0],
+    "object-shorthand": [1, "always"],
+    "one-var": [1, "never"],
+    "one-var-declaration-per-line": [0],
+    "operator-linebreak": [0],
+    "padded-blocks": [0],
+    "prefer-arrow-callback": [
+      0,
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-arrow/prefer-arrow-functions": [
+      1,
+      {
+        "disallowPrototype": false,
+        "singleReturnOnly": false,
+        "classPropertiesAllowed": false
+      }
+    ],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-exponentiation-operator": [1],
+    "prefer-numeric-literals": [1],
+    "prefer-object-has-own": [1],
+    "prefer-promise-reject-errors": [
+      0,
+      {
+        "allowEmptyReject": false
+      }
+    ],
+    "prefer-regex-literals": [
+      1,
+      {
+        "disallowRedundantWrapping": false
+      }
+    ],
+    "prefer-rest-params": [2],
+    "prefer-spread": [2],
+    "quote-props": [0],
+    "quotes": [0],
+    "react/jsx-child-element-spacing": [0],
+    "react/jsx-closing-bracket-location": [0],
+    "react/jsx-closing-tag-location": [0],
+    "react/jsx-curly-newline": [0],
+    "react/jsx-curly-spacing": [0],
+    "react/jsx-equals-spacing": [0],
+    "react/jsx-first-prop-new-line": [0],
+    "react/jsx-indent": [0],
+    "react/jsx-indent-props": [0],
+    "react/jsx-max-props-per-line": [0],
+    "react/jsx-newline": [0],
+    "react/jsx-one-expression-per-line": [0],
+    "react/jsx-props-no-multi-spaces": [0],
+    "react/jsx-space-before-closing": [0],
+    "react/jsx-tag-spacing": [0],
+    "react/jsx-wrap-multilines": [0],
+    "require-atomic-updates": [
+      1,
+      {
+        "allowProperties": false
+      }
+    ],
+    "require-await": [0],
+    "require-yield": [0],
+    "rest-spread-spacing": [0],
+    "semi": [0],
+    "semi-spacing": [0],
+    "semi-style": [0],
+    "space-after-function-name": [0],
+    "space-after-keywords": [0],
+    "space-before-blocks": [0],
+    "space-before-function-paren": [0],
+    "space-before-function-parentheses": [0],
+    "space-before-keywords": [0],
+    "space-in-brackets": [0],
+    "space-in-parens": [0],
+    "space-infix-ops": [0],
+    "space-return-throw-case": [0],
+    "space-unary-ops": [0],
+    "space-unary-word-ops": [0],
+    "standard/array-bracket-even-spacing": [0],
+    "standard/computed-property-even-spacing": [0],
+    "standard/object-curly-even-spacing": [0],
+    "strict": [1, "safe"],
+    "switch-colon-spacing": [0],
+    "symbol-description": [1],
+    "template-curly-spacing": [0],
+    "template-tag-spacing": [0],
+    "unicode-bom": [1, "never"],
+    "unicorn/better-dom-traversing": [2],
+    "unicorn/catch-error-name": [
+      2,
+      {
+        "name": "error",
+        "ignore": []
+      }
+    ],
+    "unicorn/consistent-assert": [2],
+    "unicorn/consistent-compound-words": [2, {}],
+    "unicorn/consistent-date-clone": [2],
+    "unicorn/consistent-destructuring": [0],
+    "unicorn/consistent-empty-array-spread": [2],
+    "unicorn/consistent-existence-index-check": [2],
+    "unicorn/consistent-function-scoping": [
+      0,
+      {
+        "checkArrowFunctions": true
+      }
+    ],
+    "unicorn/consistent-json-file-read": [2, "string"],
+    "unicorn/consistent-template-literal-escape": [2],
+    "unicorn/custom-error-definition": [0],
+    "unicorn/dom-node-dataset": [
+      2,
+      {
+        "preferAttributes": false
+      }
+    ],
+    "unicorn/empty-brace-spaces": [0],
+    "unicorn/error-message": [2],
+    "unicorn/escape-case": [2, "uppercase"],
+    "unicorn/expiring-todo-comments": [
+      2,
+      {
+        "terms": ["todo", "fixme", "xxx"],
+        "ignore": [],
+        "checkDates": false,
+        "checkDatesOnPullRequests": false,
+        "allowWarningComments": true
+      }
+    ],
+    "unicorn/explicit-length-check": [
+      2,
+      {
+        "non-zero": "greater-than"
+      }
+    ],
+    "unicorn/filename-case": [0],
+    "unicorn/import-style": [0, {}],
+    "unicorn/isolated-functions": [
+      2,
+      {
+        "functions": ["makeSynchronous"],
+        "selectors": [],
+        "comments": ["@isolated"],
+        "overrideGlobals": {}
+      }
+    ],
+    "unicorn/new-for-builtins": [2],
+    "unicorn/no-abusive-eslint-disable": [2],
+    "unicorn/no-accessor-recursion": [2],
+    "unicorn/no-anonymous-default-export": [2],
+    "unicorn/no-array-callback-reference": [
+      2,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/no-array-fill-with-reference-type": [2],
+    "unicorn/no-array-for-each": [0],
+    "unicorn/no-array-from-fill": [2],
+    "unicorn/no-array-method-this-argument": [2],
+    "unicorn/no-array-reduce": [
+      0,
+      {
+        "allowSimpleOperations": true
+      }
+    ],
+    "unicorn/no-array-reverse": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-array-sort": [
+      2,
+      {
+        "allowExpressionStatement": true
+      }
+    ],
+    "unicorn/no-await-expression-member": [2],
+    "unicorn/no-await-in-promise-methods": [2],
+    "unicorn/no-blob-to-file": [2],
+    "unicorn/no-canvas-to-image": [2],
+    "unicorn/no-confusing-array-splice": [2],
+    "unicorn/no-console-spaces": [2],
+    "unicorn/no-document-cookie": [2],
+    "unicorn/no-duplicate-set-values": [2],
+    "unicorn/no-empty-file": [
+      2,
+      {
+        "allowComments": false
+      }
+    ],
+    "unicorn/no-exports-in-scripts": [2],
+    "unicorn/no-for-loop": [2],
+    "unicorn/no-hex-escape": [2],
+    "unicorn/no-immediate-mutation": [2],
+    "unicorn/no-incorrect-query-selector": [2],
+    "unicorn/no-instanceof-builtins": [
+      2,
+      {
+        "useErrorIsError": false,
+        "strategy": "loose",
+        "include": [],
+        "exclude": []
+      }
+    ],
+    "unicorn/no-invalid-fetch-options": [2],
+    "unicorn/no-invalid-file-input-accept": [0],
+    "unicorn/no-invalid-remove-event-listener": [2],
+    "unicorn/no-keyword-prefix": [0, {}],
+    "unicorn/no-late-current-target-access": [2],
+    "unicorn/no-lonely-if": [2],
+    "unicorn/no-magic-array-flat-depth": [2],
+    "unicorn/no-manually-wrapped-comments": [0],
+    "unicorn/no-named-default": [2],
+    "unicorn/no-negated-condition": [2],
+    "unicorn/no-negation-in-equality-check": [2],
+    "unicorn/no-nested-ternary": [0],
+    "unicorn/no-new-array": [2],
+    "unicorn/no-new-buffer": [2],
+    "unicorn/no-null": [
+      0,
+      {
+        "checkArguments": true,
+        "checkStrictEquality": false
+      }
+    ],
+    "unicorn/no-object-as-default-parameter": [0],
+    "unicorn/no-process-exit": [2],
+    "unicorn/no-single-promise-in-promise-methods": [0],
+    "unicorn/no-static-only-class": [2],
+    "unicorn/no-thenable": [2],
+    "unicorn/no-this-assignment": [2],
+    "unicorn/no-this-outside-of-class": [2],
+    "unicorn/no-typeof-undefined": [
+      2,
+      {
+        "checkGlobalVariables": false
+      }
+    ],
+    "unicorn/no-unnecessary-array-flat-depth": [2],
+    "unicorn/no-unnecessary-array-splice-count": [2],
+    "unicorn/no-unnecessary-await": [2],
+    "unicorn/no-unnecessary-nested-ternary": [2],
+    "unicorn/no-unnecessary-polyfills": [2, {}],
+    "unicorn/no-unnecessary-slice-end": [2],
+    "unicorn/no-unreadable-array-destructuring": [2],
+    "unicorn/no-unreadable-iife": [2],
+    "unicorn/no-unused-array-method-return": [2],
+    "unicorn/no-unused-properties": [0],
+    "unicorn/no-useless-collection-argument": [2],
+    "unicorn/no-useless-error-capture-stack-trace": [2],
+    "unicorn/no-useless-fallback-in-spread": [2],
+    "unicorn/no-useless-iterator-to-array": [2],
+    "unicorn/no-useless-length-check": [2],
+    "unicorn/no-useless-promise-resolve-reject": [2],
+    "unicorn/no-useless-spread": [2],
+    "unicorn/no-useless-switch-case": [2],
+    "unicorn/no-useless-undefined": [
+      0,
+      {
+        "checkArguments": true,
+        "checkArrowFunctionBody": true
+      }
+    ],
+    "unicorn/no-zero-fractions": [2],
+    "unicorn/number-literal-case": [
+      0,
+      {
+        "hexadecimalValue": "uppercase"
+      }
+    ],
+    "unicorn/numeric-separators-style": [
+      2,
+      {
+        "onlyIfContainsSeparator": false,
+        "binary": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "octal": {
+          "minimumDigits": 0,
+          "groupLength": 4
+        },
+        "hexadecimal": {
+          "minimumDigits": 0,
+          "groupLength": 2
+        },
+        "number": {
+          "minimumDigits": 5,
+          "groupLength": 3,
+          "fractionGroupLength": "__Infinity__"
+        }
+      }
+    ],
+    "unicorn/prefer-add-event-listener": [
+      2,
+      {
+        "excludedPackages": ["koa", "sax"]
+      }
+    ],
+    "unicorn/prefer-array-find": [
+      2,
+      {
+        "checkFromLast": true
+      }
+    ],
+    "unicorn/prefer-array-flat": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-array-flat-map": [2],
+    "unicorn/prefer-array-index-of": [2],
+    "unicorn/prefer-array-last-methods": [2],
+    "unicorn/prefer-array-some": [2],
+    "unicorn/prefer-at": [
+      2,
+      {
+        "getLastElementFunctions": [],
+        "checkAllIndexAccess": false
+      }
+    ],
+    "unicorn/prefer-bigint-literals": [2],
+    "unicorn/prefer-blob-reading-methods": [2],
+    "unicorn/prefer-class-fields": [2],
+    "unicorn/prefer-classlist-toggle": [2],
+    "unicorn/prefer-code-point": [2],
+    "unicorn/prefer-date-now": [2],
+    "unicorn/prefer-default-parameters": [2],
+    "unicorn/prefer-dom-node-append": [2],
+    "unicorn/prefer-dom-node-remove": [2],
+    "unicorn/prefer-dom-node-text-content": [2],
+    "unicorn/prefer-event-target": [2],
+    "unicorn/prefer-export-from": [
+      2,
+      {
+        "checkUsedVariables": true
+      }
+    ],
+    "unicorn/prefer-get-or-insert-computed": [2],
+    "unicorn/prefer-global-this": [0],
+    "unicorn/prefer-https": [2],
+    "unicorn/prefer-import-meta-properties": [2],
+    "unicorn/prefer-includes": [2],
+    "unicorn/prefer-includes-over-repeated-comparisons": [
+      2,
+      {
+        "minimumComparisons": 3
+      }
+    ],
+    "unicorn/prefer-iterator-concat": [0],
+    "unicorn/prefer-iterator-to-array-at-end": [2],
+    "unicorn/prefer-keyboard-event-key": [2],
+    "unicorn/prefer-logical-operator-over-ternary": [2],
+    "unicorn/prefer-math-abs": [2],
+    "unicorn/prefer-math-min-max": [2],
+    "unicorn/prefer-math-trunc": [2],
+    "unicorn/prefer-modern-dom-apis": [2],
+    "unicorn/prefer-modern-math-apis": [2],
+    "unicorn/prefer-module": [2],
+    "unicorn/prefer-native-coercion-functions": [2],
+    "unicorn/prefer-negative-index": [2],
+    "unicorn/prefer-node-protocol": [2],
+    "unicorn/prefer-number-properties": [
+      2,
+      {
+        "checkInfinity": false,
+        "checkNaN": true
+      }
+    ],
+    "unicorn/prefer-object-from-entries": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-optional-catch-binding": [2],
+    "unicorn/prefer-prototype-methods": [2],
+    "unicorn/prefer-query-selector": [
+      0,
+      {
+        "allowWithVariables": false
+      }
+    ],
+    "unicorn/prefer-queue-microtask": [
+      2,
+      {
+        "checkSetImmediate": false,
+        "checkSetTimeout": false
+      }
+    ],
+    "unicorn/prefer-reflect-apply": [2],
+    "unicorn/prefer-regexp-test": [2],
+    "unicorn/prefer-response-static-json": [2],
+    "unicorn/prefer-set-has": [
+      2,
+      {
+        "minimumItems": 0
+      }
+    ],
+    "unicorn/prefer-set-size": [2],
+    "unicorn/prefer-simple-condition-first": [2],
+    "unicorn/prefer-single-call": [
+      0,
+      {
+        "ignore": []
+      }
+    ],
+    "unicorn/prefer-split-limit": [2],
+    "unicorn/prefer-spread": [2],
+    "unicorn/prefer-string-match-all": [2],
+    "unicorn/prefer-string-pad-start-end": [2],
+    "unicorn/prefer-string-raw": [2],
+    "unicorn/prefer-string-repeat": [
+      2,
+      {
+        "minimumRepetitions": 3
+      }
+    ],
+    "unicorn/prefer-string-replace-all": [2],
+    "unicorn/prefer-string-slice": [2],
+    "unicorn/prefer-string-starts-ends-with": [2],
+    "unicorn/prefer-string-trim-start-end": [2],
+    "unicorn/prefer-structured-clone": [
+      2,
+      {
+        "functions": []
+      }
+    ],
+    "unicorn/prefer-switch": [
+      2,
+      {
+        "minimumCases": 3,
+        "emptyDefaultCase": "no-default-comment"
+      }
+    ],
+    "unicorn/prefer-ternary": [0, "always"],
+    "unicorn/prefer-top-level-await": [0],
+    "unicorn/prefer-type-error": [2],
+    "unicorn/prevent-abbreviations": [0, {}],
+    "unicorn/relative-url-style": [2, "never"],
+    "unicorn/require-array-join-separator": [0],
+    "unicorn/require-css-escape": [
+      2,
+      {
+        "checkAllSelectors": false
+      }
+    ],
+    "unicorn/require-module-attributes": [2],
+    "unicorn/require-module-specifiers": [2],
+    "unicorn/require-number-to-fixed-digits-argument": [2],
+    "unicorn/require-passive-events": [2],
+    "unicorn/require-post-message-target-origin": [0],
+    "unicorn/string-content": [
+      0,
+      {
+        "patterns": {},
+        "selectors": []
+      }
+    ],
+    "unicorn/switch-case-braces": [2, "always"],
+    "unicorn/switch-case-break-position": [2],
+    "unicorn/template-indent": [
+      0,
+      {
+        "tags": ["outdent", "dedent", "gql", "sql", "html", "styled"],
+        "functions": ["dedent", "stripIndent"],
+        "selectors": [],
+        "comments": ["HTML", "indent"]
+      }
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      2,
+      {
+        "withDash": false
+      }
+    ],
+    "unicorn/throw-new-error": [2],
+    "unicorn/try-complexity": [
+      0,
+      {
+        "max": 1
+      }
+    ],
+    "use-isnan": [
+      2,
+      {
+        "enforceForIndexOf": false,
+        "enforceForSwitchCase": true
+      }
+    ],
+    "valid-typeof": [
+      2,
+      {
+        "requireStringLiterals": false
+      }
+    ],
+    "vue/array-bracket-newline": [0],
+    "vue/array-bracket-spacing": [0],
+    "vue/array-element-newline": [0],
+    "vue/arrow-spacing": [0],
+    "vue/block-spacing": [0],
+    "vue/block-tag-newline": [0],
+    "vue/brace-style": [0],
+    "vue/comma-dangle": [0],
+    "vue/comma-spacing": [0],
+    "vue/comma-style": [0],
+    "vue/dot-location": [0],
+    "vue/func-call-spacing": [0],
+    "vue/html-closing-bracket-newline": [0],
+    "vue/html-closing-bracket-spacing": [0],
+    "vue/html-end-tags": [0],
+    "vue/html-indent": [0],
+    "vue/html-quotes": [0],
+    "vue/html-self-closing": [0],
+    "vue/key-spacing": [0],
+    "vue/keyword-spacing": [0],
+    "vue/max-attributes-per-line": [0],
+    "vue/max-len": [0],
+    "vue/multiline-html-element-content-newline": [0],
+    "vue/multiline-ternary": [0],
+    "vue/mustache-interpolation-spacing": [0],
+    "vue/no-extra-parens": [0],
+    "vue/no-multi-spaces": [0],
+    "vue/no-spaces-around-equal-signs-in-attribute": [0],
+    "vue/object-curly-newline": [0],
+    "vue/object-curly-spacing": [0],
+    "vue/object-property-newline": [0],
+    "vue/operator-linebreak": [0],
+    "vue/quote-props": [0],
+    "vue/script-indent": [0],
+    "vue/singleline-html-element-content-newline": [0],
+    "vue/space-in-parens": [0],
+    "vue/space-infix-ops": [0],
+    "vue/space-unary-ops": [0],
+    "vue/template-curly-spacing": [0],
+    "wrap-iife": [0],
+    "wrap-regex": [0],
+    "yield-star-spacing": [0],
+    "yoda": [
+      1,
+      "never",
+      {
+        "exceptRange": false,
+        "onlyEquality": false
+      }
+    ]
+  }
+}

--- a/eslint/config-snapshot.test.js
+++ b/eslint/config-snapshot.test.js
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { ESLint } from "eslint";
+import javascriptBrowserPreset from "./presets/javascript-browser.js";
+import javascriptNodePreset from "./presets/javascript-node.js";
+import javascriptPreset from "./presets/javascript.js";
+import typescriptNodePreset from "./presets/typescript-node.js";
+import typescriptReactPreset from "./presets/typescript-react.js";
+import typescriptPreset from "./presets/typescript.js";
+
+const updateSnapshots = process.argv.includes("--update");
+const snapshotsDirectory = join(import.meta.dirname, "__snapshots__");
+
+/** @type {ReadonlyArray<{ name: string; preset: import("eslint").Linter.Config[]; files: readonly string[] }>} */
+const presetMatrix = [
+  {
+    name: "javascript",
+    preset: javascriptPreset,
+    files: ["main.js", "main.test.js"],
+  },
+  {
+    name: "javascript-browser",
+    preset: javascriptBrowserPreset,
+    files: ["main.js", "main.test.js"],
+  },
+  {
+    name: "javascript-node",
+    preset: javascriptNodePreset,
+    files: ["main.js", "main.test.js"],
+  },
+  {
+    name: "typescript",
+    preset: typescriptPreset,
+    files: ["main.ts", "main.d.ts", "main.test.ts"],
+  },
+  {
+    name: "typescript-node",
+    preset: typescriptNodePreset,
+    files: ["main.ts", "main.d.ts", "main.test.ts"],
+  },
+  {
+    name: "typescript-react",
+    preset: typescriptReactPreset,
+    files: ["main.tsx", "main.ts", "main.test.tsx"],
+  },
+];
+
+/** @param {Record<string, unknown> | undefined} rules */
+function sortRules(rules) {
+  return Object.fromEntries(
+    Object.entries(rules ?? {}).toSorted(
+      (
+        /** @type {[string, unknown]} */ [left],
+        /** @type {[string, unknown]} */ [right],
+      ) => left.localeCompare(right),
+    ),
+  );
+}
+
+/** @param {unknown} value */
+function normalizeForSnapshot(value) {
+  return snapshotParse(snapshotStringify(value));
+}
+
+/** @param {unknown} value */
+function snapshotStringify(value) {
+  return `${JSON.stringify(
+    value,
+    (_key, currentValue) => {
+      if (currentValue === Infinity) {
+        return "__Infinity__";
+      }
+
+      if (currentValue === -Infinity) {
+        return "__NegativeInfinity__";
+      }
+
+      return currentValue;
+    },
+    2,
+  )}\n`;
+}
+
+/** @param {string} text */
+function snapshotParse(text) {
+  return JSON.parse(text, (_key, currentValue) => {
+    if (currentValue === "__Infinity__") {
+      return Infinity;
+    }
+
+    if (currentValue === "__NegativeInfinity__") {
+      return -Infinity;
+    }
+
+    return currentValue;
+  });
+}
+
+/** @param {import("eslint").Linter.Config[]} preset @param {string} filePath */
+async function resolveRules(preset, filePath) {
+  const eslint = new ESLint({
+    overrideConfigFile: true,
+    baseConfig: preset,
+  });
+
+  const { rules } = await eslint.calculateConfigForFile(filePath);
+  return normalizeForSnapshot(sortRules(rules));
+}
+
+/** @param {string} presetName @param {import("eslint").Linter.Config[]} preset @param {readonly string[]} files */
+async function snapshotPreset(presetName, preset, files) {
+  /** @type {Record<string, Record<string, unknown>>} */
+  const snapshot = {};
+
+  for (const filePath of files) {
+    snapshot[filePath] = await resolveRules(preset, filePath);
+  }
+
+  const snapshotPath = join(snapshotsDirectory, `${presetName}.json`);
+
+  if (updateSnapshots) {
+    await mkdir(snapshotsDirectory, { recursive: true });
+    await writeFile(snapshotPath, snapshotStringify(snapshot));
+    console.log(`updated ${snapshotPath}`);
+    return;
+  }
+
+  const expected = snapshotParse(await readFile(snapshotPath, "utf8"));
+
+  for (const filePath of files) {
+    assert.deepEqual(
+      snapshot[filePath],
+      expected[filePath],
+      `${presetName} rules for ${filePath} differ from snapshot; run npm run test:snapshot:update and review the diff`,
+    );
+  }
+}
+
+for (const { name, preset, files } of presetMatrix) {
+  await snapshotPreset(name, preset, files);
+}
+
+if (updateSnapshots) {
+  console.log("Snapshots updated.");
+} else {
+  console.log("ESLint config snapshots match.");
+}

--- a/eslint/config-snapshot.test.js
+++ b/eslint/config-snapshot.test.js
@@ -97,24 +97,45 @@ function snapshotParse(text) {
   });
 }
 
-/** @param {import("eslint").Linter.Config[]} preset @param {string} filePath */
-async function resolveRules(preset, filePath) {
-  const eslint = new ESLint({
-    overrideConfigFile: true,
-    baseConfig: preset,
-  });
+/** @param {string} snapshotPath @param {string} presetName */
+async function readSnapshot(snapshotPath, presetName) {
+  try {
+    return await readFile(snapshotPath, "utf8");
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      /** @type {NodeJS.ErrnoException} */ (error).code === "ENOENT"
+    ) {
+      throw new Error(
+        `Missing snapshot for preset "${presetName}" at ${snapshotPath}; run npm run test:snapshot:update to create it`,
+        { cause: error },
+      );
+    }
 
+    throw error;
+  }
+}
+
+/** @param {import("eslint").ESLint} eslint @param {string} filePath */
+async function resolveRules(eslint, filePath) {
   const { rules } = await eslint.calculateConfigForFile(filePath);
   return normalizeForSnapshot(sortRules(rules));
 }
 
 /** @param {string} presetName @param {import("eslint").Linter.Config[]} preset @param {readonly string[]} files */
 async function snapshotPreset(presetName, preset, files) {
+  // One ESLint instance per preset is enough; reuse it for every file so the
+  // plugin/config loading only happens once per preset.
+  const eslint = new ESLint({
+    overrideConfigFile: true,
+    baseConfig: preset,
+  });
+
   /** @type {Record<string, Record<string, unknown>>} */
   const snapshot = {};
 
   for (const filePath of files) {
-    snapshot[filePath] = await resolveRules(preset, filePath);
+    snapshot[filePath] = await resolveRules(eslint, filePath);
   }
 
   const snapshotPath = join(snapshotsDirectory, `${presetName}.json`);
@@ -126,7 +147,7 @@ async function snapshotPreset(presetName, preset, files) {
     return;
   }
 
-  const expected = snapshotParse(await readFile(snapshotPath, "utf8"));
+  const expected = snapshotParse(await readSnapshot(snapshotPath, presetName));
 
   for (const filePath of files) {
     assert.deepEqual(

--- a/eslint/presets/typescript.test/string-coercion.ts
+++ b/eslint/presets/typescript.test/string-coercion.ts
@@ -1,0 +1,22 @@
+const objectValue = { id: 1 };
+
+// no-base-to-string: object has only the default Object.prototype.toString,
+// so this interpolates to "[object Object]" at runtime.
+// eslint-disable-next-line @typescript-eslint/no-base-to-string
+export const interpolated = `value: ${objectValue}`;
+
+// restrict-plus-operands allows string + number, so this concatenation is fine
+// and needs no disable directive.
+export const withNumber = "count: " + 1;
+
+// allowNumberAndString is narrow: only number is allowed, so other primitive
+// operands are still caught (the disable directives only pass because the rule
+// actually reports here, thanks to reportUnusedDisableDirectives).
+// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+export const withBoolean = "flag: " + true;
+// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+export const withNullish = "value: " + null;
+
+// And a non-string/non-number addition (true would silently become 1) is caught too.
+// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+export const added = 1 + true;

--- a/eslint/review-config-snapshot.prompt.md
+++ b/eslint/review-config-snapshot.prompt.md
@@ -1,0 +1,47 @@
+# Review a failing ESLint config snapshot
+
+Use this prompt when [`config-snapshot.test.js`](./config-snapshot.test.js) fails (run via `npm run test:snapshot`).
+
+A failure means the resolved rule set of one or more presets changed, almost always because an ESLint plugin or `typescript-eslint` was upgraded. The committed JSON in [`__snapshots__/`](./__snapshots__/) no longer matches what the presets resolve to. Your job is to figure out **what changed and whether we want it**, not to blindly accept the new output.
+
+## Our philosophy (read before judging)
+
+See the root [`README.md`](../README.md). In short:
+
+- **Correctness first.** We mostly want to catch control-flow bugs, security issues, and a11y problems, ideally using type information.
+- **Moderate, opinionated consistency.** A consistent, modern, idiomatic style that is easy to read and refactor is good.
+- **No pedantic rules.** We do **not** want stylistic nitpicks or rules that favor one feature over an equally fine alternative. Every rule must be justified by objective criteria. "I find it easier to read" is not enough.
+- **Tests may be less strict** than app code.
+
+## Steps
+
+1. **Regenerate the snapshots** so you can see the diff:
+
+   ```sh
+   npm run test:snapshot:update
+   ```
+
+2. **Review the diff** (`git diff eslint/__snapshots__/`). Go through every change and classify it:
+   - **Rules removed / turned off** — Was this intentional (e.g. a rule was renamed, deprecated, or merged into another)? If a rule we relied on for correctness silently disappeared, that is a regression to flag, not accept.
+   - **Severity changes** (`error` ↔ `warn` ↔ `off`) — Does the new severity match how strict we want to be in that context (app code vs. tests)?
+   - **Option changes** — Did defaults change in a way that makes a rule stricter, looser, or more pedantic?
+   - **New rules** — Why was it added? Does it match our philosophy?
+
+3. **Make an educated guess per change** and decide:
+   - **Keep it** if it improves correctness, security, a11y, or sensible consistency, and is not pedantic.
+   - **Turn it off** (in the relevant `eslint/rules/*` or preset source — **not** by editing the snapshot by hand) if it is pedantic, purely stylistic, or contradicts our philosophy.
+   - When a useful rule was removed/renamed upstream, consider wiring up its replacement so we don't lose the coverage.
+
+4. **Re-run** `npm run test:snapshot:update` after any source change so the committed snapshots reflect your final decision, then `npm run test:snapshot` to confirm it passes.
+
+5. **Implement your recommendation** with the smallest reasonable change and keep the snapshots in sync.
+
+## Finally
+
+Summarize for the user:
+
+- which rules were **removed/disabled** and whether that looks intentional,
+- which rules are **new** and your keep/disable recommendation for each, with a one-line justification grounded in our philosophy,
+- any change you were **unsure** about.
+
+Then ask the user to make the final judgement before committing — do not rubber-stamp snapshot updates.

--- a/eslint/rules/typescript.js
+++ b/eslint/rules/typescript.js
@@ -55,7 +55,6 @@ export const typescript =
             "warn",
             ...ruleOptions["@typescript-eslint/naming-convention"].defaultRules,
           ],
-          "@typescript-eslint/no-base-to-string": "off", // https://typescript-eslint.io/rules/no-base-to-string
           "@typescript-eslint/no-confusing-void-expression": [
             // https://typescript-eslint.io/rules/no-confusing-void-expression
             "off",
@@ -116,7 +115,20 @@ export const typescript =
             },
           ],
           "@typescript-eslint/require-await": "off", // https://typescript-eslint.io/rules/require-await
-          "@typescript-eslint/restrict-plus-operands": "off", // https://typescript-eslint.io/rules/restrict-plus-operands
+          "@typescript-eslint/restrict-plus-operands": [
+            // https://typescript-eslint.io/rules/restrict-plus-operands
+            "error",
+            {
+              // Concatenating a string with a number is unproblematic and ergonomic.
+              // The other operands are kept strict (the rule's own schema defaults
+              // are permissive, so they must be spelled out as false explicitly).
+              allowAny: false,
+              allowBoolean: false,
+              allowNullish: false,
+              allowNumberAndString: true,
+              allowRegExp: false,
+            },
+          ],
           "@typescript-eslint/restrict-template-expressions": [
             // https://typescript-eslint.io/rules/restrict-template-expressions
             "off",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "test:format": "prettier --check .",
     "test:lint": "eslint --cache --max-warnings 0 .",
     "test:publishable": "node ./semantic-release/verify-publishable.js",
+    "test:snapshot": "node eslint/config-snapshot.test.js",
+    "test:snapshot:update": "node eslint/config-snapshot.test.js --update",
     "test:presets:javascript": "cd eslint/presets/javascript.test; eslint --cache --max-warnings 0 .",
     "test:presets:typescript": "cd eslint/presets/typescript.test; eslint --cache --max-warnings 0 .",
     "test:presets:typescript-react": "cd eslint/presets/typescript-react.test; eslint --cache --max-warnings 0 .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": ["./typescript/base.json", "./typescript/js-lib.json"],
   "compilerOptions": {
+    "lib": ["es2024"],
     "rootDir": ".",
     "skipLibCheck": true,
     "types": ["node"]


### PR DESCRIPTION
## Summary
- Add snapshot tests that resolve each ESLint preset's effective rules via `calculateConfigForFile`, with committed JSON in `eslint/__snapshots__/` and `test:snapshot` / `test:snapshot:update` scripts
- Enable `@typescript-eslint/no-base-to-string` and `@typescript-eslint/restrict-plus-operands` (with `allowNumberAndString: true` and other operands kept strict), plus a fixture demonstrating both rules
- Restore `lib: ["es2024"]` on the root `tsconfig.json` so typechecking matches `base.json` intent, and document snapshot review workflow in `AGENTS.md`

## Test plan
- [x] `npm run test:snapshot`
- [x] `npm run test:presets:typescript`
- [x] `npm run test:types`